### PR TITLE
Official affiliation

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,7 @@ hiredis==2.0.0  # https://github.com/redis/hiredis-py
 celery==5.2.3  # pyup: < 6.0  # https://github.com/celery/celery
 django-celery-beat==2.2.1  # https://github.com/celery/django-celery-beat
 flower==1.0.0  # https://github.com/mher/flower
+kshingle==0.9.10
 
 # Django
 # ------------------------------------------------------------------------------

--- a/scholarly_articles/models.py
+++ b/scholarly_articles/models.py
@@ -110,7 +110,10 @@ class Contributors(models.Model):
 
 class Affiliations(models.Model):
     name = models.CharField(_("Affiliation Name"), max_length=510, null=True, blank=True)
-    official = models.ForeignKey(Institution, verbose_name=_("Official Affiliation Name"), on_delete=models.SET_NULL, max_length=1020, null=True, blank=True)
+    official = models.ForeignKey(Institution, verbose_name=_("Official Affiliation Name"),
+                                 on_delete=models.SET_NULL, max_length=1020, null=True, blank=True)
+    score = models.CharField(_("Similarity Coefficient"), max_length=5, null=True, blank=True)
+
 
     def __unicode__(self):
         return self.name
@@ -126,6 +129,7 @@ class Affiliations(models.Model):
     panels = [
         FieldPanel('name'),
         FieldPanel('official'),
+        FieldPanel('score'),
     ]
 
 

--- a/scholarly_articles/unpaywall/affiliation_predictor.py
+++ b/scholarly_articles/unpaywall/affiliation_predictor.py
@@ -1,0 +1,34 @@
+import kshingle as ks
+
+from institution.models import Institution
+
+
+def is_brazil(name):
+    return 'brasil' or 'brazil' in clean_affiliation(name)
+
+def clean_affiliation(name):
+    name = name.replace(';', ',')
+    names = name.split(',')
+    return [name.strip().lower() for name in names]
+
+def official(affiliation_name):
+    institutions = Institution.objects.all()
+    if affiliation_name:
+        score = 0
+        official = None
+        for name in clean_affiliation(str(affiliation_name)):
+            for institution in institutions:
+                jaccard_index = ks.jaccard_strings(name, str(institution.name).lower(), k=4)
+                if jaccard_index > score:
+                    score = jaccard_index
+                    official = institution
+
+        return official, str(score)[:4]
+
+
+def run(affiliation_name):
+    official(affiliation_name)
+
+
+if __name__ == '__main__':
+    run(affiliation_name=None)

--- a/scholarly_articles/unpaywall/load_data.py
+++ b/scholarly_articles/unpaywall/load_data.py
@@ -142,7 +142,12 @@ def load(from_year, resource_type):
 
     rawunpaywall = models.RawUnpaywall.objects.filter(year__gte=from_year, resource_type=resource_type)
     for item in rawunpaywall:
-        if not item.is_paratext:
+        brazil = False
+        for author in item.json.get('z_authors') or []:
+            if author.get('affiliation'):
+                if affiliation_predictor.is_brazil(author['affiliation'][0]['name']) == 'brasil':
+                    brazil = True
+        if not item.is_paratext and brazil:
             try:
                 load_article(item.json)
             except (ArticleSaveError, JournalSaveError, ContributorSaveError, AffiliationSaveError) as e:

--- a/scholarly_articles/wagtail_hooks.py
+++ b/scholarly_articles/wagtail_hooks.py
@@ -105,6 +105,7 @@ class AffiliationsAdmin(ModelAdmin):
     list_display = (
         'name',
         'official',
+        'score',
     )
     #list_filter = ('name',)
     search_fields = ('name', 'official',)


### PR DESCRIPTION
#### O que esse PR faz?
Funcionalidades propostas neste PR:

1. Verificar se ao menos um autor é vinculado à uma instituição no Brasil;
2. Adicionar os campos `official` e `score` ao modelo de Afiliações, note que, de forma prelimiar, todas as instituições declaradas são correlacionadas com um nome de instituição oficial (lista controlada) e que os scores indicam nenhuma similaridade ou similaridade total para valores entre zero e um, respectivamente.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
É preciso instalar o pacote `kshingle==0.9.10`, que foi adicionado ao arquivo _requerements.py_, todas as modificações implementadas estão associadas à `task` `scholarly_articles.tasks.load_journal_articles` que pode ser chamada via interface gráfica.

#### Algum cenário de contexto que queira dar?
Obseva-se que há registros de contribuidores que não são do Brasil, isso ocorre pois, provavelmente, há uma associação de autores brasileiros e estrangeiros a um mesmo artigo.

### Screenshots
![image](https://user-images.githubusercontent.com/41302084/190808824-6aae6bca-76d8-4975-b741-f1438640073d.png)

#### Quais são tickets relevantes?
TK #59

### Referências
NA.

