### PR TITLE
Adiciona a propriedade 'data' aos modelos

### DIFF
--- a/location/models.py
+++ b/location/models.py
@@ -40,6 +40,17 @@ class Location(CommonControlField):
     def __str__(self):
         return u'%s: %s | %s: %s | %s: %s' % (_('Country'), self.country, _('State'),  self.state, _('City'), self.city, )
 
+    @property
+    def data(self):
+        d = {}
+        if self.country:
+            d.update(self.country.data)
+        if self.state:
+            d.update(self.state.data)
+        if self.city:
+            d.update(self.city.data)
+        return d
+
     @classmethod
     def get_or_create(cls, user, location_country, location_state, location_city):
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a propriedade `data` ao modelo `location`, por exemplo:
`{'country__name_pt': 'Brasil', 'country__name_en': 'Brazil', 'country__capital': 'Brasília', 'country__acron3': 'BRA', 'country__acron2': 'BR'}`

#### Onde a revisão poderia começar?
NA.

#### Como este poderia ser testado manualmente?
NA.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #103 

### Referências
NA.

