### PR TITLE
Adiciona a propriedade 'data' ao modelo Infrastructure

### DIFF
--- a/infrastructure_directory/models.py
+++ b/infrastructure_directory/models.py
@@ -66,6 +66,38 @@ class InfrastructureDirectory(CommonControlField):
     def __str__(self):
         return u'%s' % self.title
 
+    @property
+    def data(self):
+        d = {
+            "infrastructure__title": self.title,
+            "infrastructure__link": self.link,
+            "infrastructure__description": self.description,
+            "infrastructure__classification": self.classification,
+            "infrastructure__keywords": [keyword for keyword in self.keywords.iterator()],
+            "infrastructure__record_status": self.record_status,
+            "infrastructure__source": self.source
+        }
+
+        if self.institutions:
+            inst = []
+            for institution in self.institutions.iterator():
+                inst.append(institution.data)
+            d.update({"infrastructure__institutions": inst})
+
+        if self.thematic_areas:
+            area = []
+            for thematic_area in self.thematic_areas.iterator():
+                area.append(thematic_area.data)
+            d.update({"infrastructure__thematic_areas": area})
+
+        if self.practice:
+            d.update(self.practice.data)
+
+        if self.action:
+            d.update(self.action.data)
+
+        return d
+
     base_form_class = InfrastructureDirectoryForm
 
 class InfrastructureDirectoryFile(CommonControlField):


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a propriedade `data` ao modelo `infrastructure_directory`, por exemplo:
`{'infrastructure__title': 'teste', 'infrastructure__link': 'https://teste.com.br', 'infrastructure__description': 'teste', 'infrastructure__classification': 'portal', 'infrastructure__keywords': [<Tag: teste>, <Tag: teste3>, <Tag: teste2>], 'infrastructure__record_status': 'WIP', 'infrastructure__source': 'teste'}`

#### Onde a revisão poderia começar?
NA.

#### Como este poderia ser testado manualmente?
NA.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #105 (`infrastructure_directory`)

### Referências
NA.

