### PR TITLE
Improves country identification

### DIFF
--- a/scholarly_articles/scripts/set_country.py
+++ b/scholarly_articles/scripts/set_country.py
@@ -2,10 +2,17 @@ from django.db.models import Q
 
 from scholarly_articles import models
 from usefulmodels.models import Country
+from institution.models import Institution
 
 
 def run():
-    #first iteration to identify country by name
+    #first iteration to identify country by institution ROR
+    for institution_ror in Institution.objects.filter(source="ROR").iterator():
+        for aff in models.Affiliations.objects.filter(name__icontains=institution_ror.name,
+                                                      country__isnull=True).iterator():
+            aff.country = institution_ror.location.country
+
+    #second iteration to identify country by declared name
     for country in Country.objects.all():
         for aff in models.Affiliations.objects.filter(
                 Q(name__icontains=country.name_en) | Q(name__icontains=country.name_pt),
@@ -13,9 +20,9 @@ def run():
             aff.country = country
             aff.save()
 
-        #second iteration to identify country by acronym with 3 char
+        #second iteration to identify country by declared acronym with 3 char
         for aff in models.Affiliations.objects.filter(
-                name__icontains=country.acron3,
+                Q(name__contains=" "+country.acron3+" ") | Q(name__contains=" "+country.acron3),
                 country__isnull=True,
                 official__isnull=True).iterator():
             aff.country = country

--- a/scholarly_articles/scripts/set_country.py
+++ b/scholarly_articles/scripts/set_country.py
@@ -11,6 +11,7 @@ def run():
         for aff in models.Affiliations.objects.filter(name__icontains=institution_ror.name,
                                                       country__isnull=True).iterator():
             aff.country = institution_ror.location.country
+            aff.save()
 
     for country in Country.objects.all():
         #second iteration to identify country by declared name

--- a/scholarly_articles/scripts/set_country.py
+++ b/scholarly_articles/scripts/set_country.py
@@ -12,17 +12,25 @@ def run():
                                                       country__isnull=True).iterator():
             aff.country = institution_ror.location.country
 
-    #second iteration to identify country by declared name
     for country in Country.objects.all():
+        #second iteration to identify country by declared name
         for aff in models.Affiliations.objects.filter(
                 Q(name__icontains=country.name_en) | Q(name__icontains=country.name_pt),
                   country__isnull=True, official__isnull=True).iterator():
             aff.country = country
             aff.save()
 
-        #second iteration to identify country by declared acronym with 3 char
+        #third iteration to identify country by declared acronym with 3 char
         for aff in models.Affiliations.objects.filter(
-                Q(name__contains=" "+country.acron3+" ") | Q(name__contains=" "+country.acron3),
+                Q(name__contains=", "+country.acron3+", ") | Q(name__endswith=", "+country.acron3),
+                country__isnull=True,
+                official__isnull=True).iterator():
+            aff.country = country
+            aff.save()
+
+        #fourth iteration to identify country by declared acronym with 2 char
+        for aff in models.Affiliations.objects.filter(
+                Q(name__contains=", " + country.acron2 + ", ") | Q(name__endswith=", " + country.acron2),
                 country__isnull=True,
                 official__isnull=True).iterator():
             aff.country = country

--- a/usefulmodels/fixtures/countries.csv
+++ b/usefulmodels/fixtures/countries.csv
@@ -146,6 +146,7 @@ Quénia;Kenya;Nairóbi;KEN;KE
 Quirguistão;Kyrgyzstan;Bisqueque;KGZ;KG
 Quiribáti;Kiribati;Taraua do Sul;KIR;KI
 Reino Unido;Uk;Londres;GBR;GB
+Reino Unido;United Kingdom;Londres;GBR;GB
 República Centro-Africana;Central African Republic;Bangui;CAF;CF
 República Checa;Czech Republic;Praga;CZE;CZ
 República Democrática do Congo;Democratic Republic Of Congo;Quinxassa;COD;CD


### PR DESCRIPTION
#### O que esse PR faz?
Considera os registros `ROR` para a identificação do país de uma afiliação.

#### Onde a revisão poderia começar?
NA.

#### Como este poderia ser testado manualmente?
NA.

#### Algum cenário de contexto que queira dar?
Foram testadas 540 afiliações declaradas, deste total, os seguintes registros não tiveram o país identificado:
`School of Chemical, Biological and Materials Engineering University of Oklahoma Norman Oklahoma`
`Public Health Agency of Poniente`
`Torrecárdenas University Hospital`
`Federal University of Pernambuco`
`Central Clinical School, University of Sydney & Centre for Cardiovascular Science, University of Edinburgh, Edinburgh, Scotland`
`Centers for Disease Control and Prevention`
`Università Degli Studi del Sannio, Italia`
`Università Degli Studi di Salerno, Italia; Università Degli Studi del Sannio, Italia`

Os seguintes registros foram classificados errôneamente:
`Department of Management, Technology, and Economics, ETH Zurich, Zurich 8092, Switzerland` - `Etiópia`

### Screenshots
NA.

#### Quais são tickets relevantes?
#124 

### Referências
NA.

