### PR TITLE
Change on delete attribute value

### DIFF
--- a/core/home/models.py
+++ b/core/home/models.py
@@ -21,7 +21,7 @@ class HomePage(Page):
 
 
 class FormField(AbstractFormField):
-    page = ParentalKey('FormPage', on_delete=models.CASCADE, related_name='form_fields')
+    page = ParentalKey('FormPage', on_delete=models.SET_NULL, related_name='form_fields')
 
 
 class FormPage(WagtailCaptchaEmailForm):

--- a/core/models.py
+++ b/core/models.py
@@ -34,7 +34,7 @@ class CommonControlField(models.Model):
         verbose_name=_("Creator"),
         related_name="%(class)s_creator",
         editable=False,
-        on_delete=models.CASCADE,
+        on_delete=models.SET_NULL,
     )
 
     # Last modifier user
@@ -45,7 +45,7 @@ class CommonControlField(models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.CASCADE,
+        on_delete=models.SET_NULL,
     )
 
     class Meta:

--- a/location/models.py
+++ b/location/models.py
@@ -13,11 +13,11 @@ from .forms import LocationForm
 
 class Location(CommonControlField):
 
-    city = models.ForeignKey(City, verbose_name=_("City"), on_delete=models.CASCADE,
+    city = models.ForeignKey(City, verbose_name=_("City"), on_delete=models.SET_NULL,
                              null=True, blank=True)
-    state = models.ForeignKey(State, verbose_name=_("State"), on_delete=models.CASCADE,
+    state = models.ForeignKey(State, verbose_name=_("State"), on_delete=models.SET_NULL,
                               null=True, blank=True)
-    country = models.ForeignKey(Country, verbose_name=_("Country"), on_delete=models.CASCADE,
+    country = models.ForeignKey(Country, verbose_name=_("Country"), on_delete=models.SET_NULL,
                                 null=True, blank=True)
 
     autocomplete_search_field = 'state__name'


### PR DESCRIPTION
#### O que esse PR faz?
Altera o valor do atributo `on_delete` de `CASCADE` para `SET_NULL` nos `apps`: 
- `core`
- `location`

`Apps` não alterados:
- `blog`
- `django_celery_beat`

#### Onde a revisão poderia começar?
NA.

#### Como este poderia ser testado manualmente?
NA.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

