### PR TITLE
Sanitização dos periódicos.

### DIFF
--- a/django_celery_beat/views.py
+++ b/django_celery_beat/views.py
@@ -22,7 +22,7 @@ def task_run(request):
 
     # Add user id to the kwargs
     kwargs = json.loads(p_task.kwargs)
-    # kwargs["user_id"] = request.user.id
+    kwargs["user_id"] = request.user.id
 
     task.apply_async(
         args=json.loads(p_task.args),

--- a/scholarly_articles/scripts/remove_orphans_journal.py
+++ b/scholarly_articles/scripts/remove_orphans_journal.py
@@ -1,0 +1,6 @@
+from scholarly_articles.tasks import remove_orphans_journals
+
+
+def run(user_id):
+    if user_id:
+        remove_orphans_journals.apply_async(args=(user_id, ))

--- a/scholarly_articles/scripts/sanitize_journal.py
+++ b/scholarly_articles/scripts/sanitize_journal.py
@@ -1,0 +1,6 @@
+from scholarly_articles.tasks import sanitize_all_journals
+
+
+def run(user_id):
+    if user_id:
+        sanitize_all_journals.apply_async(args=(user_id, ))

--- a/scholarly_articles/utils.py
+++ b/scholarly_articles/utils.py
@@ -1,0 +1,102 @@
+from django.db.models import Q
+from scholarly_articles import models
+
+
+def check_articles_journals():
+    """
+    This function return journals that dont have article associate.
+
+    return a list of journals without articles associate.
+    """
+    journals_without_articles = []
+
+    for journal in models.Journals.objects.all():
+        articles = models.ScholarlyArticles.objects.filter(journal=journal)
+
+        if len(articles) == 0:
+            journals_without_articles.append(models.Journals.objects.get(pk=journal.id))
+
+    return journals_without_articles
+
+
+def check_duplicate_journal(journal=None):
+    """
+    This function return if there is duplicate journals.
+
+    Return a list with the reference to journal and the size of the duplications.
+    """
+
+    if journal.journal_issn_l and journal.journal_issns and journal.journal_name:
+        journals = models.Journals.objects.filter(
+            Q(journal_issn_l=journal.journal_issn_l)
+            | Q(journal_issns__icontains=journal.journal_issns)
+            | Q(journal_name__iexact=journal.journal_name)
+        )
+    elif journal.journal_issn_l and journal.journal_issns:
+        journals = models.Journals.objects.filter(
+            Q(journal_issn_l=journal.journal_issn_l)
+            | Q(journal_issns__icontains=journal.journal_issns)
+        )
+    elif journal.journal_issns and journal.journal_name:
+        journals = models.Journals.objects.filter(
+            Q(journal_issns__icontains=journal.journal_issns)
+            | Q(journal_name__iexact=journal.journal_name)
+        )
+    elif journal.journal_issn_l and journal.journal_name:
+        journals = models.Journals.objects.filter(
+            Q(journal_issn_l=journal.journal_issn_l)
+            | Q(journal_name__iexact=journal.journal_name)
+        )
+    elif journal.journal_issn_l:
+        journals = models.Journals.objects.filter(
+            Q(journal_issn_l=journal.journal_issn_l)
+        )
+    elif journal.journal_issns:
+        journals = models.Journals.objects.filter(
+            Q(journal_issns__icontains=journal.journal_issns)
+        )
+    elif journal.journal_name:
+        journals = models.Journals.objects.filter(
+            Q(journal_name__iexact=journal.journal_name)
+        )
+
+    if journals:
+        qt = len(journals)
+        if qt > 1:
+            return journals
+
+
+def check_articles_without_journals():
+    """
+    This function return articles without journal associate.
+
+    Return a list of articles(object)
+    """
+    articles_without_journals = []
+
+    for article in models.ScholarlyArticles.objects.iterator():
+        if not article.journal:
+            articles_without_journals.append(article)
+
+    return articles_without_journals
+
+
+def reassignment_articles(cast_journal, journals):
+    """
+    This function receive a casted journal and a list of journals to search by article.
+
+    This found articles must be reassignment to the casted journal.
+
+    Return a list of articles reassigned.
+    """
+    articles = None
+
+    for journal in journals:
+        articles = models.ScholarlyArticles.objects.filter(journal=journal)
+
+        for article in articles:
+            article.journal = cast_journal
+            article.save()  
+
+    return articles
+


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR adiciona a capacidade de identificar periódicos duplicados no projeto.

#### Onde a revisão poderia começar?

Sugiro olhar a lista de commits.

#### Como este poderia ser testado manualmente?

E possível testar manualmente utilizando alguns comandos, segue: 


Execução por linha de comando para remover periódicos orfãos: 

`python manage.py runscript remove_orphans_journal --script-args 1`

Execução por linha de comando para sanitizar os periódicos: 

`python manage.py runscript sanitize_journal --script-args 1`


#### Algum cenário de contexto que queira dar?

Essa atividade é uma de 3 atividades de sanitização na base de dados.

### Screenshots

Imagem da execução das tarefas: 

![Screenshot 2023-07-11 at 10 54 53](https://github.com/scieloorg/scms-oca/assets/86991526/e4ab23e8-5555-4067-b2e0-7253a9d88af0)


#### Quais são tickets relevantes?

#215 

### Referências
N/A

