### PR TITLE
Adiciona o param ``pipeline`` para garantir que seja utilizado na indexação do ES

### DIFF
--- a/article/search_indexes.py
+++ b/article/search_indexes.py
@@ -67,6 +67,9 @@ class ArticleIndex(indexes.SearchIndex, indexes.Indexable):
     # Database
     database = indexes.MultiValueField(null=True)
 
+    # Pipeline
+    pipeline = indexes.CharField(null=True)
+
     # Graphs
     graphs = indexes.MultiValueField(null=True)
 
@@ -120,6 +123,9 @@ class ArticleIndex(indexes.SearchIndex, indexes.Indexable):
     # def prepare_record_type(self, obj):
     #     return "article"
 
+    def prepare_pipeline(self, obj):
+        return "oca"
+    
     def prepare_universe(self, obj):
         return ["brazil"]
 

--- a/education_directory/search_indexes.py
+++ b/education_directory/search_indexes.py
@@ -58,6 +58,9 @@ class EducationIndex(indexes.SearchIndex, indexes.Indexable):
     # Database
     database = indexes.MultiValueField(null=True)
 
+    # Pipeline
+    pipeline = indexes.CharField(null=True)
+
     # Graphs
     graphs = indexes.MultiValueField(null=True)
 
@@ -104,6 +107,9 @@ class EducationIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_database(self, obj):
         return ["ocabr"]
+    
+    def prepare_pipeline(self, obj):
+        return "oca"
 
     def prepare_graphs(self, obj):
         return [

--- a/event_directory/search_indexes.py
+++ b/event_directory/search_indexes.py
@@ -58,6 +58,9 @@ class EventIndex(indexes.SearchIndex, indexes.Indexable):
     # Database
     database = indexes.MultiValueField(null=True)
 
+    # Pipeline
+    pipeline = indexes.CharField(null=True)
+
     # Graphs
     graphs = indexes.MultiValueField(null=True)
 
@@ -89,6 +92,9 @@ class EventIndex(indexes.SearchIndex, indexes.Indexable):
         if obj.creator:
             return obj.creator.username
         
+    def prepare_pipeline(self, obj):
+        return "oca"
+    
     def prepare_updated_by(self, obj):
         if obj.updated_by:
             return obj.updated_by.username

--- a/infrastructure_directory/search_indexes.py
+++ b/infrastructure_directory/search_indexes.py
@@ -60,6 +60,9 @@ class InfraStructureIndex(indexes.SearchIndex, indexes.Indexable):
     # Database
     database = indexes.MultiValueField(null=True)
 
+    # Pipeline
+    pipeline = indexes.CharField(null=True)
+
     # Graphs
     graphs = indexes.MultiValueField(null=True)
 
@@ -99,6 +102,9 @@ class InfraStructureIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_database(self, obj):
         return ["ocabr"]
+    
+    def prepare_pipeline(self, obj):
+        return "oca"
 
     def prepare_graphs(self, obj):
         return [

--- a/policy_directory/search_indexes.py
+++ b/policy_directory/search_indexes.py
@@ -51,6 +51,9 @@ class PolicyIndex(indexes.SearchIndex, indexes.Indexable):
     # Database
     database = indexes.MultiValueField(null=True)
 
+    # Pipeline
+    pipeline = indexes.CharField(null=True)
+
     # Graphs
     graphs = indexes.MultiValueField(null=True)
 
@@ -94,6 +97,9 @@ class PolicyIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_database(self, obj):
         return ["ocabr"]
+    
+    def prepare_pipeline(self, obj):
+        return "oca"
 
     def prepare_graphs(self, obj):
         return [


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR tem como objetivo adicionar um parâmetro para garantir que seja utilizado um pipeline no momento de indexação do Elasticsearch. 

#### Onde a revisão poderia começar?

Para revisar é necessário criar um pipeline no Kibana chamado **oca** e realizar a indexação de um conteúdo com a espectativa de que o que foi definido no pipeline seja executado. 

#### Como este poderia ser testado manualmente?

Realizando a reindexação do conteúdo no ES: 


```shell
python manage.py rebuild_index -u es
```

#### Algum cenário de contexto que queira dar?

É importante para realizar e revisar essa atividade ter o conhecimento em Pipelines no Kibana, mais sobre é possível nesse link: https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html


### Screenshots

Exemplos de alguns pipelines: 


![Screenshot 2025-01-21 at 08 30 20](https://github.com/user-attachments/assets/c81047e0-a0aa-40de-ba3a-11b5831fa47f)




#### Quais são tickets relevantes?

Não há tíquete para essa atividade, em reunião com @robertatakenaka e Abel foi solicitado alterações de alguns termos e portanto o uso de pipelines resolve sem realizar alterações que "quebre" outro módulos da aplicação.
 
### Referências

- https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html


