### PR TITLE
Fix: correções de alinhamento no arquivo chart.html e ajuste no mega-…

### DIFF
--- a/chart/templates/chart/chart.html
+++ b/chart/templates/chart/chart.html
@@ -16,46 +16,45 @@
 
 <secton id="content" class="mt-5">
     <div class="container">
-        <div class="row">
-            <div class="col pl-0">
-
-                <div class="page-title-row mb-4" style="background:#F9F9F9;border-radius:4px;">
-                    <div class="page-title-content py-2 px-2">
-                        <h1 class="mb-1">Indicadores</h1>
-                        <span>Painel de dados do Observatório OCABr</span>
-                    </div>
-                </div>
-
+        <div class="row bg-light rounded my-3">
+            <div class="col">
+                <header class="my-2">
+                    <h1 class="mb-1">Indicadores</h1>
+                    <p class="text-muted">Painel de dados do Observatório OCABr</p>
+                </header>
             </div>
         </div>
 
         <div class="row">
+            
             {% if request.user.is_authenticated %}
-                <div class="col-md-12 mb-3">
+                <div class="col mb-2">
                     <p class="text-muted">
                         Link para o dash: <a href="{{ selected_chart.link_chart }}" target="_blank">{{selected_chart.link_chart}}</a><br>
                         Link para o admin do chart: <a href="/admin/chart/chart/edit/{{selected_chart.id}}" target="_blank">{{selected_chart.title}}</a>
                     </p>
                 </div>
             {% endif %}
-             <div class="mt-12 mb-2">
-                    <b>Escolha o gráfico:</b>
-                </div>
-                <form method="post" action="" class="form-group row">
+
+            <div class="col mb-2">
+                <label for="chart_label" class="fw-bold">Escolha o gráfico:</label>
+                <form method="post" action="">
                     {% csrf_token %} 
-                    <select name="chart_label" id="chart_label" class="form-select m-3">
+                    <select name="chart_label" id="chart_label" class="form-control mt-2">
                         {% for chart in charts %}
-                            <option value="{{chart.label}}" {% if selected_chart.label == chart.label %}selected=""{% endif %}>{{ chart.title }}</option>
+                            <option value="{{chart.label}}" {% if selected_chart.label == chart.label %}selected{% endif %}>{{ chart.title }}</option>
                         {% endfor %}
                     </select>
                 </form>
+            </div>
+            
         </div>
         <div class="row">
 
             <!-- Content -->
-            <div class="col-lg-12">
-                <!-- Graph -->
+            <div class="col">
 
+                <!-- Graph -->
                     <div class="mb-2 mx-auto">
                         <div id="graph" style="position: relative;">{{selected_chart.iframe_url|safe}}</div>
                     </div>

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -43,9 +43,6 @@
       {% endif %}
 
       <title>{% block title %}{{settings.core_settings.CustomSettings.name}}{% endblock title %}</title>
-
-      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-
      
       {% block extra_head %}{% endblock extra_head %}
 
@@ -95,7 +92,7 @@
         <script src="{% static 'js/custom.js' %}"></script>
       {% endcompress %}
       
-      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+      <script src="{% static 'js/bootstrap.min.js' %}" crossorigin="anonymous"></script>
 
       {% block inline_javascript %}
 

--- a/core/templates/menus/mega_menu.html
+++ b/core/templates/menus/mega_menu.html
@@ -48,7 +48,35 @@
             transform: translateY(0);
         }
     }
-    
+
+    .mega-menu{
+        background-color: #FFF;
+        box-shadow: 0px 13px 42px 11px rgba(0, 0, 0, 0.05);
+        border: 1px solid #EEE;
+        border-top: 2px solid #034E8E;
+        color: #666;
+    }
+
+
+    .mega-menu a{
+        color: #666;
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        letter-spacing: 0;
+        font-family: 'Lato', sans-serif;
+        font-weight: 700
+    }
+    .mega-menu a:hover{
+        color: #034E8E;
+    }
+
+    .menu-item-empty{
+        padding: 0.25rem 1.5rem;
+    }
+
+    .menu-link.dropdown-toggle.show{
+        color: #034E8E;
+    }
 </style>
 
 <div class="collapse navbar-collapse" id="navbarMega">
@@ -78,7 +106,7 @@
                     <li class="fw-semibold">Países/Regiões</li>
                     <li><a class="dropdown-item" href="/chart?menu_scope=evolucao-producao-mundo-pais-documentos">Documentos</a></li>
                     <li><a class="dropdown-item" href="/chart?menu_scope=evolucao-producao-mundo-pais-citacoes">Citações</a></li>
-                    <li><a href="#" class="dropdown-item">&nbsp;</a></li>
+                    <li class="menu-item-empty">&nbsp;</li>
                     <li class="fw-semibold mt-2">Instituições</li>
                     <li><a class="dropdown-item" href="/chart?menu_scope=evolucao-producao-mundo-instituicao-pais-documentos">Documentos</a></li>
                     <li><a class="dropdown-item" href="/chart?menu_scope=evolucao-producao-mundo-instituicao-pais-citacoes">Citações</a></li>
@@ -90,7 +118,7 @@
                     <li class="fw-semibold">Países/Regiões</li>
                     <li><a class="dropdown-item" href="/chart?menu_scope=evolucao-producao-brasil-pais-documentos">Documentos</a></li>
                     <li><a class="dropdown-item" href="/chart?menu_scope=evolucao-producao-brasil-pais-citacoes">Citações</a></li>
-                    <li><a href="#" class="dropdown-item">&nbsp;</a></li>
+                    <li class="menu-item-empty">&nbsp;</li>
                     <li class="fw-semibold mt-2">Instituições</li>
                     <li><a class="dropdown-item" href="/chart?menu_scope=evolucao-producao-brasil-instituicao-pais-documentos">Documentos</a></li>
                     <li><a class="dropdown-item" href="/chart?menu_scope=evolucao-producao-brasil-instituicao-pais-citacoes">Citações</a></li>
@@ -117,7 +145,7 @@
                 <ul class="list-unstyled ps-4">
                     <li class="fw-semibold">Países/Regiões</li>
                     <li><a class="dropdown-item" href="/chart?menu_scope=evolucao-producaosocial-pais-documentos">Documentos</a></li>
-                    <li><a href="#" class="dropdown-item">&nbsp;</a></li>
+                    <li class="menu-item-empty">&nbsp;</li>
                 </ul>
                 </div>
             </div>


### PR DESCRIPTION
Fix: correções de alinhamento no arquivo chart.html e ajuste no mega-menu. Remoção da chamada duplicada do bootstrap5. A versão do css que está nativa no sistema é bootstrap 4.

#### O que esse PR faz?
- remove a duplicidade da chamada bootstrap.css
- ajusta elementos de alinhamento como inclusão de header e remoção de classes desnecessárias ao layout
- ajusta o mega-menu para que se pareça mais com o menu padrão do sistema

#### Onde a revisão poderia começar?
Carregue os arquivos e navegue no link:
/pt-br/chart/?menu_scope=evolucao-producao-mundo-pais-documentos

#### Como este poderia ser testado manualmente?
Siga os passos descritos anteriormente

#### Algum cenário de contexto que queira dar?
Ao verificar a versão do bootstrap utilizada no sistema, percebi que o css está com a aversão 4 e o js está com a versão 5. Recomendo que seja avaliada qual a melhor versão a ser utilizada e que se padronize a mesma versão no css e js.

### Screenshots
<img width="1468" height="811" alt="Screen Shot 2025-08-09 at 13 43 43" src="https://github.com/user-attachments/assets/65ff3c59-71ac-4ff0-ac5e-d9c155a1c959" />
<img width="1465" height="800" alt="Screen Shot 2025-08-09 at 13 43 36" src="https://github.com/user-attachments/assets/e93b9d7e-505f-44ae-8d0c-2b73948be037" />
<img width="1516" height="486" alt="Screen Shot 2025-08-09 at 13 43 28" src="https://github.com/user-attachments/assets/6b9f0ab0-5e7e-4618-8cb9-f3942ace9e46" />


#### Quais são tickets relevantes?
-

### Referências
https://getbootstrap.com/docs/4.6/components/forms/

