### PR TITLE
Altera exibição dos titulos apontando para o site externo dos itens no resultado do Search

### DIFF
--- a/search/templates/search/include/result_item.html
+++ b/search/templates/search/include/result_item.html
@@ -8,18 +8,13 @@
 <div class="card mb-3 result-item">
     <div class="card-body">
         <h5 class="card-title">
-        {% for location in doc.source.locations %}
-            {% if forloop.first %}
-                <a href="{{ location.landing_page_url }}" target="_blank" class="text-decoration-none">
-                    {{ doc.source.title }}
-                </a>
-            {% else %}
-                <span class="text-muted">|</span>
-                <a href="{{ location.landing_page_url }}" target="_blank" class="text-decoration-none">
-                    {{ doc.source.title }}
-                </a>
-            {% endif %}
-        {% endfor %}
+        {% if doc.source.locations %}
+            <a href="{{ doc.source.locations.0.landing_page_url }}" target="_blank" class="text-decoration-none">
+                {{ doc.source.title }}
+            </a>
+        {% else %}
+            <a href="{{pageurl}}" target="_blank" class="text-decoration-none">{{ doc.source.title }}</a>
+        {% endif %}
         </h5>
         {% if doc.source.authorships %}
             <p class="card-text">


### PR DESCRIPTION
#### O que esse PR faz?
Altera o template para exibir apenas o primeiro landing_url do payload do item. Se não houver landing_url, exibe o titulo sem redirecionamento para o item.

#### Onde a revisão poderia começar?
commits

#### Como este poderia ser testado manualmente?
Acessar a página do search

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

