### PR TITLE
Melhora js e css para lidar com ocultação automáticade do cabeçalho

### DIFF
--- a/core/static/css/custom.css
+++ b/core/static/css/custom.css
@@ -50,6 +50,26 @@
   border-bottom: 0.1rem solid #1c438c !important;
 }
 
+/* Oculta o header ao rolar para baixo (controlado via JS em custom.js)
+   - remove o espaço reservado do .header-wrap-clone para o conteúdo ocupar mais área
+*/
+@media (min-width: 992px) {
+  /* Mantém as transições existentes do tema e adiciona a do hide/show */
+  #header-wrap {
+    transition: height .2s ease 0s, background-color .3s ease 0s, transform .25s ease;
+    will-change: transform;
+  }
+}
+
+body.header-hidden #header-wrap {
+  transform: translate3d(0, -100%, 0);
+  pointer-events: none;
+}
+
+body.header-hidden .header-wrap-clone {
+  height: 0 !important;
+}
+
 /* Muda cor do footer para azul claro */
 #footer {
   background-color: #f1f2f4 !important;

--- a/core/static/css/style.css
+++ b/core/static/css/style.css
@@ -3384,14 +3384,17 @@ html[xmlns] .slider-wrap {
 
 .header-size-sm #header-wrap #logo img {
 	height: 60px;
+	width: auto;
 }
 
 .header-size-md #header-wrap #logo img {
 	height: 80px;
+	width: auto;
 }
 
 .header-size-lg #header-wrap #logo img {
 	height: 120px;
+	width: auto;
 }
 
 #logo a.standard-logo {
@@ -3412,6 +3415,7 @@ html[xmlns] .slider-wrap {
 
 	.sticky-header-shrink #header-wrap #logo img {
 		height: 60px;
+		width: auto;
 	}
 
 }

--- a/core/static/js/custom.js
+++ b/core/static/js/custom.js
@@ -5,3 +5,57 @@ $('.lang-select').change(function(){
     $('#language').val($(this).val());
     $('#form_lang').submit();
 });
+
+// Oculta o header quando o usuário rola para baixo e mostra ao rolar para cima.
+// A classe no <body> controla o CSS (ver custom.css).
+(function () {
+    const headerWrap = document.getElementById('header-wrap');
+    if (!headerWrap) return;
+
+    const body = document.body;
+    let lastScrollY = window.scrollY || 0;
+    const delta = 10; // ignora micro-movimentos
+    const threshold = 120; // só esconde depois de passar uma altura mínima
+    let ticking = false;
+
+    function applyHeaderVisibility(currentScrollY) {
+        // Se o menu mobile estiver aberto, não esconder (evita UX estranha)
+        if (body.classList.contains('primary-menu-open')) {
+            body.classList.remove('header-hidden');
+            lastScrollY = currentScrollY;
+            return;
+        }
+
+        if (currentScrollY <= 0) {
+            body.classList.remove('header-hidden');
+            lastScrollY = currentScrollY;
+            return;
+        }
+
+        if (Math.abs(currentScrollY - lastScrollY) < delta) {
+            lastScrollY = currentScrollY;
+            return;
+        }
+
+        if (currentScrollY > lastScrollY && currentScrollY > threshold) {
+            body.classList.add('header-hidden');
+        } else {
+            body.classList.remove('header-hidden');
+        }
+
+        lastScrollY = currentScrollY;
+    }
+
+    function onScroll() {
+        const currentScrollY = window.scrollY || 0;
+        if (ticking) return;
+        ticking = true;
+        window.requestAnimationFrame(function () {
+            applyHeaderVisibility(currentScrollY);
+            ticking = false;
+        });
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    applyHeaderVisibility(window.scrollY || 0);
+})();

--- a/core/templates/include/header.html
+++ b/core/templates/include/header.html
@@ -52,7 +52,7 @@
       </div>
     </div>
   </div>
-  <div class="header-wrap-clone" style="height: 100px;"></div>
+  <div class="header-wrap-clone"></div>
 </header>
 <!-- header -->
 


### PR DESCRIPTION
This pull request introduces a feature to hide the site header when the user scrolls down and reveal it when scrolling up, improving the viewing area and user experience, especially on larger screens. The implementation includes both JavaScript logic for toggling the header and corresponding CSS for smooth transitions. Additionally, some minor adjustments are made to logo image sizing and header layout.

Header hide/show functionality:

* Added JavaScript in `custom.js` to detect scroll direction and toggle a `header-hidden` class on the `<body>`, hiding the header when scrolling down and showing it when scrolling up. The logic also ensures the header remains visible when the mobile menu is open and ignores small scroll movements.
* Updated `custom.css` to provide CSS transitions for the header's hide/show effect and remove reserved space when the header is hidden by adjusting `.header-wrap-clone`.
* Removed the fixed height from `.header-wrap-clone` in `header.html` to allow the content to occupy more space when the header is hidden.

Logo and header styling improvements:

* Ensured logo images maintain their aspect ratio by setting `width: auto;` for various header sizes in `style.css`. [[1]](diffhunk://#diff-b53cfec5a0e3cf1ee6fc4d70e8687517932dc5674789ef24ee9366f1bb4b1a4dR3387-R3397) [[2]](diffhunk://#diff-b53cfec5a0e3cf1ee6fc4d70e8687517932dc5674789ef24ee9366f1bb4b1a4dR3418)