### PR TITLE
Ativa operador boleano para campo author's country em World

### DIFF
--- a/search_gateway/data_sources_with_settings.py
+++ b/search_gateway/data_sources_with_settings.py
@@ -249,7 +249,7 @@ DATA_SOURCES = {
                     "class_filter": "select2",
                     "label": _("Country"),
                     "support_search_as_you_type": False,
-                    "support_query_operator": False,
+                    "support_query_operator": True,
                     "display_transform": "country",
                 },
             },


### PR DESCRIPTION
This pull request makes a minor update to the country filter settings in the `search_gateway/data_sources_with_settings.py` file. The change enables support for query operators in the country filter, allowing users to use advanced search operators when filtering by country.

* Enabled support for query operators in the country filter by setting `support_query_operator` to `True` in the filter configuration.