### PR TITLE
Remove título de breadcrumb em páginas básicas

### DIFF
--- a/core/templates/include/breadcrumb.html
+++ b/core/templates/include/breadcrumb.html
@@ -2,6 +2,5 @@
 
 <section class="mt-5 pt-3 bg-white">
     <div class="container clearfix">
-        <h2 class="fw-bold text-oca-blue-title">{{ page.title }}</h2>
     </div>
 </section>


### PR DESCRIPTION
This pull request makes a minor update to the breadcrumb template by removing the page title heading from the `breadcrumb.html` file. This change likely aims to simplify the UI or prevent duplicate headings.