### PR TITLE
Fix/journal aggr and title

### DIFF
--- a/indicator/search/query.py
+++ b/indicator/search/query.py
@@ -105,7 +105,7 @@ def add_must_terms(name, values, must):
 
 def _get_periodical_identifier_field(field_settings):
     """Return a keyword field suitable for cardinality of periodicals."""
-    for candidate in ("issn", "journal", "source_name"):
+    for candidate in ("journal", "source_name", "issn"):
         fl = field_settings.get(candidate, {}).get("index_field_name")
         if fl:
             if not str(fl).endswith(".keyword"):

--- a/indicator/static/indicator/js/charts.js
+++ b/indicator/static/indicator/js/charts.js
@@ -138,15 +138,15 @@ Indicators.renderChart = function({ chartId, chartDivId, data, seriesType, title
         }
     } else {
         if (seriesType === 'Periodicals') {
-            series = [{ name: 'Unique Periodicals (sources)', type: chartType, data: data.nperiodicals_per_year || [] }];
-        } else if (seriesType === 'Documents per Periodical') {
-            series = [{ name: 'Documents / Periodical', type: chartType, data: data.docs_per_periodical_per_year || [] }];
-        } else if (seriesType === 'Citations per Periodical') {
-            series = [{ name: 'Citations / Periodical', type: chartType, data: data.citations_per_periodical_per_year || [] }];
-        } else if (seriesType === 'Cited Documents per Periodical') {
-            series = [{ name: 'Cited Documents / Periodical', type: chartType, data: data.cited_docs_per_periodical_per_year || [] }];
-        } else if (seriesType === 'Percent Periodicals With Cited Docs') {
-            series = [{ name: '% Periodicals With ≥1 Cited Document', type: chartType, data: data.percent_periodicals_with_cited_docs_per_year || [] }];
+            series = [{ name: 'Unique Journals (sources)', type: chartType, data: data.nperiodicals_per_year || [] }];
+        } else if (seriesType === 'Documents per Journal') {
+            series = [{ name: 'Documents / Journal', type: chartType, data: data.docs_per_periodical_per_year || [] }];
+        } else if (seriesType === 'Citations per Journal') {
+            series = [{ name: 'Citations / Journal', type: chartType, data: data.citations_per_periodical_per_year || [] }];
+        } else if (seriesType === 'Cited Documents per Journal') {
+            series = [{ name: 'Cited Documents / Journal', type: chartType, data: data.cited_docs_per_periodical_per_year || [] }];
+        } else if (seriesType === 'Percent Journals With Cited Docs') {
+            series = [{ name: '% Journals With ≥1 Cited Document', type: chartType, data: data.percent_periodicals_with_cited_docs_per_year || [] }];
         } else if (seriesType === 'Cited Documents') {
             series = [{ name: 'Cited Documents', type: chartType, data: data.docs_with_citations_per_year || [] }];
         } else if (seriesType === 'Documents') {


### PR DESCRIPTION
This pull request standardizes terminology from "Periodical" to "Journal" across both backend and frontend code, improving consistency in how journal-related data is handled and displayed. Additionally, it updates the field selection logic to prioritize "journal" and "source_name" over "issn" when identifying periodicals.

Terminology updates in frontend chart labels:
- Updated chart series names and types in `indicator/static/indicator/js/charts.js` to use "Journal" instead of "Periodical" for better clarity and consistency in the user interface.

Backend field selection logic:
- Changed the order of candidate fields in `_get_periodical_identifier_field` in `indicator/search/query.py` to prioritize "journal" and "source_name" before "issn" when determining the keyword field for periodicals.