### PR TITLE
Corrige chamadas AJAX para campos SAYT em indicadores

### DIFF
--- a/indicator/static/indicator/js/button.js
+++ b/indicator/static/indicator/js/button.js
@@ -87,13 +87,16 @@ function setupSelect2SearchAsYouType(fieldId, data_source, placeholder=null, all
             $(selectElement).select2(
                 {
                     ajax: {
-                        url: `/search-gateway/search-as-you-type/?field_name=${fieldId}&data_source=${data_source}`,
+                        url: `/search-gateway/search-as-you-type/?field_name=${fieldId}&data_source=${data_source}&use_data_source_model=false`,
                         dataType: 'json',
-                        delay: 300,
+                        delay: 100,
                         data: params => ({q: params.term}),
                         processResults: data => {
+                            const results = Array.isArray(data)
+                                ? data
+                                : (Array.isArray(data.results) ? data.results : []);
                             return {
-                                results: data.results.map(item => ({
+                                results: results.map(item => ({
                                     id: item.key,
                                     text: item.key
                                 }))

--- a/search_gateway/views.py
+++ b/search_gateway/views.py
@@ -69,10 +69,17 @@ def search_item_view(request):
 @require_GET
 def search_as_you_type_view(request):
     q = request.GET.get("q", "")
-    data_source_name = request.GET.get("index_name")
+    data_source_name = request.GET.get("data_source") or request.GET.get("index_name")
     field_name = request.GET.get("field_name", "")
+    use_data_source_model = _parse_bool_param(request.GET.get("use_data_source_model", "true"))
+
     try:
-        results = controller.search_as_you_type(data_source_name, q, field_name)
+        results = controller.search_as_you_type(
+            data_source_name,
+            q, 
+            field_name, 
+            use_data_source_model=use_data_source_model
+        )
     except Exception as e:
         return JsonResponse({"error": str(e)}, status=500) # TODO: Handle different error codes
-    return JsonResponse(results, safe=False)
+    return JsonResponse({"results": results})


### PR DESCRIPTION
This pull request updates the search-as-you-type functionality to allow bypassing the `DataSource` model and use a more direct configuration-based approach when specified. It also improves the robustness of the frontend and backend integration, and adjusts the response format for consistency.

**Backend enhancements and flexibility:**

* Added a `use_data_source_model` parameter to the `search_as_you_type` controller and view, allowing the search logic to use either the `DataSource` model or a direct configuration-based approach for retrieving settings. This enables more flexible and efficient queries, especially for data sources that don't require model lookups. [[1]](diffhunk://#diff-17b01317aa680e7f18d7e227c19bdc7dea37471b5332c609f4dc7feb09cdc639L13-R64) [[2]](diffhunk://#diff-960459c31a8f65739c0e1e7fc2f43872d8712208d43a6c96bde8290c5928e0eaL72-R85)
* Improved error handling and validation in the search controller by checking for required parameters and returning empty results when necessary, preventing unnecessary errors.

**Frontend and API integration:**

* Updated the frontend JavaScript (`setupSelect2SearchAsYouType`) to always pass `use_data_source_model=false` in the AJAX request, ensuring the backend uses the new direct configuration path. Also reduced the request delay for a more responsive user experience and made the results parsing more robust.
* Standardized the API response format for search-as-you-type endpoints to always return results under a `results` key, improving consistency for consumers.