### PR TITLE
Cria menu flat com item institucional e faz outras melhoras

### DIFF
--- a/core/static/css/custom.css
+++ b/core/static/css/custom.css
@@ -182,7 +182,7 @@
     margin-top: 2rem;
   }
 
-  .primary-menu .mobile-primary-menu .menu-container {
+  .primary-menu .mobile-primary-menu > .mobile-menu-section > .menu-container {
     display: flex;
     flex-direction: column;
     width: 100%;
@@ -203,11 +203,12 @@
     width: 100%;
     margin-right: 0 !important;
     white-space: normal;
-    padding: 0.65rem 0.9rem !important;
+    padding: 0.65rem 2.7rem 0.65rem 0.9rem !important;
     background-color: #ebeff7 !important;
     color: #1c438c !important;
     font-size: 1rem !important;
     font-weight: 700 !important;
+    text-transform: lowercase !important;
     letter-spacing: 0 !important;
     box-shadow: 0 4px 0 0 transparent !important;
     border: none !important;
@@ -223,7 +224,7 @@
   }
 
   .primary-menu .mobile-primary-menu .mobile-menu-list-top > .menu-item > .menu-link {
-    text-transform: capitalize !important;
+    text-transform: lowercase !important;
   }
 
   .primary-menu .mobile-primary-menu .mobile-menu-list-bottom > .menu-item > .menu-link {
@@ -231,13 +232,71 @@
     font-size: 0.95rem !important;
   }
 
-  .primary-menu .mobile-primary-menu .sub-menu-container {
+  .primary-menu .mobile-primary-menu .menu-item > .sub-menu-container {
+    display: none;
     margin-top: 0.5rem !important;
     padding-left: 0.9rem !important;
   }
 
   .primary-menu .mobile-primary-menu .sub-menu-container .menu-item + .menu-item {
     margin-top: 0.4rem;
+  }
+
+  .primary-menu .mobile-primary-menu .sub-menu-container .menu-link {
+    text-transform: lowercase !important;
+  }
+
+  .primary-menu .mobile-primary-menu .menu-link div > i.icon-angle-down {
+    display: none !important;
+  }
+
+  .primary-menu .mobile-primary-menu .menu-item .sub-menu-trigger {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    top: 0.5rem;
+    right: 0.35rem;
+    width: 1.45rem;
+    height: 1.45rem;
+    min-width: 1.45rem;
+    min-height: 1.45rem;
+    padding: 0;
+    line-height: 1;
+    border-radius: 0.2rem;
+    background-color: #dbe4f3;
+    color: #1c438c;
+    z-index: 3;
+    text-align: center;
+    font-size: 0 !important;
+    box-sizing: border-box;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  .primary-menu .mobile-primary-menu .flat-menu > ul > li > .sub-menu-trigger {
+    width: 1.45rem !important;
+    height: 1.45rem !important;
+    min-width: 1.45rem !important;
+    min-height: 1.45rem !important;
+    padding: 0 !important;
+    line-height: 1 !important;
+    border-radius: 0.2rem !important;
+  }
+
+  .primary-menu .mobile-primary-menu .mobile-flat-menu > .sub-menu-trigger {
+    display: none !important;
+  }
+
+  .primary-menu .mobile-primary-menu .menu-item .sub-menu-trigger::before {
+    content: "▾" !important;
+    font-family: Arial, sans-serif !important;
+    font-size: 0.95rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .primary-menu .mobile-primary-menu .menu-item .sub-menu-trigger.icon-rotate-90 {
+    transform: none !important;
   }
 
   /* No mobile, a observação (sub-menu-horizontal) vira lista vertical */
@@ -401,7 +460,7 @@ nav.primary-menu .sub-menu-horizontal .menu-item.active > a.menu-link {
   margin: 0 0 0.5rem 0 !important;
   padding: 0 !important;
   color: #1c438c !important;
-  font-size: 0.9rem !important;
+  font-size: 0.95rem !important;
 }
 
 .flat-menu.with_heading > ul {
@@ -467,6 +526,13 @@ nav.primary-menu .sub-menu-horizontal .menu-item.active > a.menu-link {
 
   #header .header-row .flat-menu.no_heading > ul > li {
     margin: 0 !important;
+    padding-bottom: 0.35rem;
+    margin-bottom: -0.35rem !important;
+    position: relative;
+  }
+
+  #header .header-row .flat-menu.no_heading > ul > li:hover {
+    z-index: 500;
   }
 
   #header .header-row .flat-menu.no_heading > ul > li > a {
@@ -477,8 +543,8 @@ nav.primary-menu .sub-menu-horizontal .menu-item.active > a.menu-link {
     border: none !important;
     border-radius: 0 !important;
     color: #1c438c !important;
-    font-size: 1rem !important;
-    font-weight: 700 !important;
+    font-size: 0.95rem !important;
+    font-weight: 600 !important;
     text-transform: lowercase !important;
     text-decoration: none !important;
     white-space: nowrap;
@@ -487,6 +553,107 @@ nav.primary-menu .sub-menu-horizontal .menu-item.active > a.menu-link {
   #header .header-row .flat-menu.no_heading > ul > li > a:hover,
   #header .header-row .flat-menu.no_heading > ul > li > a:focus {
     text-decoration: none !important;
+  }
+
+  #header .header-row .flat-menu.no_heading .sub-menu-container {
+    display: none !important;
+    position: absolute;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: max-content;
+    margin: 0 !important;
+    padding: 0.35rem !important;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+    pointer-events: auto !important;
+    z-index: 520;
+  }
+
+  #header .header-row .flat-menu.no_heading .sub-menu-container::before {
+    content: "";
+    position: absolute;
+    top: -0.45rem;
+    left: 0;
+    right: 0;
+    height: 0.45rem;
+  }
+
+  #header .header-row .flat-menu.no_heading .menu-item:hover > .sub-menu-container {
+    display: flex !important;
+  }
+
+  #header .header-row .flat-menu.no_heading > ul > li > .sub-menu-container > li {
+    margin: 0 !important;
+    padding-bottom: 0 !important;
+    margin-bottom: 0 !important;
+    position: relative;
+  }
+
+  #header .header-row .flat-menu.no_heading > ul > li > .sub-menu-container > li > .menu-link {
+    display: inline-block;
+    margin-right: 0 !important;
+    padding: 0.45rem 0.85rem !important;
+    border-radius: 0.3rem !important;
+    background-color: #ebeff7 !important;
+    color: #1c438c !important;
+    font-size: 0.95rem !important;
+    font-weight: 600 !important;
+    text-transform: lowercase !important;
+    line-height: 1.2 !important;
+    white-space: nowrap;
+  }
+
+  #header .header-row .flat-menu.no_heading > ul > li > .sub-menu-container > li:hover > .menu-link {
+    background-color: #ced9ed !important;
+  }
+
+  #header .header-row .flat-menu.no_heading > ul > li > .sub-menu-container > li:hover {
+    z-index: 501;
+  }
+
+  #header .header-row .flat-menu.no_heading > ul > li > .sub-menu-container .sub-menu-container {
+    top: 0;
+    left: 100%;
+    transform: none;
+    margin-left: 0.15rem !important;
+  }
+
+  #header .header-row .flat-menu.no_heading > ul > li > .sub-menu-container .sub-menu-container::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -0.2rem;
+    width: 0.2rem;
+    height: 100%;
+  }
+
+  #header .header-row .flat-menu.no_heading > ul > li > .sub-menu-container .sub-menu-container > li {
+    margin: 0 !important;
+  }
+
+  #header .header-row .flat-menu.no_heading > ul > li > .sub-menu-container .sub-menu-container > li > .menu-link {
+    display: inline-block;
+    margin-right: 0 !important;
+    padding: 0.4rem 0.8rem !important;
+    border-radius: 0.3rem !important;
+    background-color: #ebeff7 !important;
+    color: #1c438c !important;
+    font-size: 0.9rem !important;
+    font-weight: 600 !important;
+    text-transform: lowercase !important;
+    line-height: 1.2 !important;
+    white-space: nowrap;
+  }
+
+  #header .header-row .flat-menu.no_heading > ul > li > .sub-menu-container .sub-menu-container > li:hover > .menu-link {
+    background-color: #ced9ed !important;
   }
 }
 

--- a/core/static/js/custom.js
+++ b/core/static/js/custom.js
@@ -12,3 +12,105 @@ $('.lang-select').change(function(){
     // Auto-hide desativado.
     document.body.classList.remove('header-hidden');
 })();
+
+// Mobile menu: em itens com submenu, o toque no rótulo também abre/fecha
+// o acordeão (além do botão de seta), evitando navegação acidental imediata.
+(function () {
+    const mobileQuery = window.matchMedia('(max-width: 991.98px)');
+    const rootSelector = '.primary-menu .mobile-primary-menu';
+    const submenuSelector = '.sub-menu-container, .mega-menu-content';
+    const triggerSelector = '.sub-menu-trigger';
+    const menuSyncDelay = 220;
+    const flatMenuItemSelector = '.mobile-flat-menu .flat-menu .menu-item';
+
+    function syncTriggerStates(rootElement) {
+        const root = rootElement && rootElement.length ? rootElement : $(rootSelector);
+
+        root.find('.menu-item').each(function () {
+            const menuItem = $(this);
+            const submenu = menuItem.children(submenuSelector);
+            const trigger = menuItem.children(triggerSelector);
+
+            if (!submenu.length || !trigger.length) {
+                return;
+            }
+
+            const isOpen = submenu.is(':visible');
+            trigger.toggleClass('icon-rotate-90', isOpen);
+            menuItem.toggleClass('submenu-open', isOpen);
+        });
+    }
+
+    function toggleFlatMenuItem(menuItem) {
+        const submenu = menuItem.children(submenuSelector);
+        const trigger = menuItem.children(triggerSelector);
+        if (!submenu.length || !trigger.length) {
+            return false;
+        }
+
+        const shouldOpen = !submenu.is(':visible');
+        const siblingItems = menuItem.siblings('.menu-item');
+
+        siblingItems.children(submenuSelector).filter(':visible').stop(true, true).slideUp(menuSyncDelay);
+        siblingItems.children(triggerSelector).removeClass('icon-rotate-90');
+        siblingItems.removeClass('submenu-open');
+
+        submenu.stop(true, true).slideToggle(menuSyncDelay);
+        trigger.toggleClass('icon-rotate-90', shouldOpen);
+        menuItem.toggleClass('submenu-open', shouldOpen);
+
+        return true;
+    }
+
+    $(document).on('click', `${rootSelector} .menu-item > .menu-link`, function (event) {
+        if (!mobileQuery.matches) {
+            return;
+        }
+
+        const flatMenuItem = $(this).closest(flatMenuItemSelector);
+        if (flatMenuItem.length) {
+            const toggled = toggleFlatMenuItem(flatMenuItem);
+            if (toggled) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            }
+            return;
+        }
+
+        const menuItem = $(this).parent('.menu-item');
+        const submenu = menuItem.children(submenuSelector);
+        if (!submenu.length) {
+            return;
+        }
+
+        event.preventDefault();
+        const trigger = menuItem.children('.sub-menu-trigger');
+        if (trigger.length) {
+            trigger.trigger('click');
+            const root = menuItem.closest(rootSelector);
+            window.setTimeout(function () {
+                syncTriggerStates(root);
+            }, menuSyncDelay);
+        }
+    });
+
+    $(document).on('click', `${rootSelector} .menu-item > .sub-menu-trigger`, function (event) {
+        if (!mobileQuery.matches) {
+            return;
+        }
+
+        const flatMenuItem = $(this).closest(flatMenuItemSelector);
+        if (flatMenuItem.length) {
+            const root = $(this).closest(rootSelector);
+            window.setTimeout(function () {
+                syncTriggerStates(root);
+            }, menuSyncDelay);
+            return;
+        }
+
+        const root = $(this).closest(rootSelector);
+        window.setTimeout(function () {
+            syncTriggerStates(root);
+        }, menuSyncDelay);
+    });
+})();

--- a/core/templates/include/header.html
+++ b/core/templates/include/header.html
@@ -51,7 +51,7 @@
               <ul class="menu-container mobile-menu-list mobile-menu-list-right">
                 {% for handle in config.WAGTAILMENUS_FLAT_MENUS_HANDLE_CHOICES %}
                   <li class="menu-item mobile-flat-menu">
-                    {% flat_menu handle.0 max_levels=2 show_menu_heading=True fall_back_to_default_site_menus=False %}
+                    {% flat_menu handle.0 max_levels=4 show_menu_heading=True fall_back_to_default_site_menus=False template='menus/flat_menu.html' sub_menu_template='menus/flat_menu_sub_menu.html' %}
                   </li>
                 {% endfor %}
               </ul>
@@ -59,9 +59,9 @@
           </div>
         </nav>
         
-        <div class="d-none d-lg-flex align-items-center ms-auto">
+        <div class="primary-menu d-none d-lg-flex align-items-center ms-auto">
           {% for handle in config.WAGTAILMENUS_FLAT_MENUS_HANDLE_CHOICES %}
-              {% flat_menu handle.0 max_levels=2 show_menu_heading=True fall_back_to_default_site_menus=False %}
+              {% flat_menu handle.0 max_levels=4 show_menu_heading=True fall_back_to_default_site_menus=False template='menus/flat_menu.html' sub_menu_template='menus/flat_menu_sub_menu.html' %}
           {% endfor %}
           <span class="mx-2">{% include 'include/language.html' %}</span>
           

--- a/core/templates/menus/flat_menu.html
+++ b/core/templates/menus/flat_menu.html
@@ -1,0 +1,20 @@
+{% load menu_tags %}
+
+<div class="flat-menu {{ menu_handle }} {% if menu_heading %}with_heading{% else %}no_heading{% endif %}">
+  {% if show_menu_heading and menu_heading %}
+    <h4>{{ menu_heading|safe }}</h4>
+  {% endif %}
+
+  {% if menu_items %}
+    <ul class="menu-container">
+      {% for item in menu_items %}
+        <li class="menu-item {{ item.active_class }}{% if item.has_children_in_menu %} sub-menu{% endif %}">
+          <a class="menu-link" href="{{ item.href }}"><div>{{ item.text }}</div></a>
+          {% if item.has_children_in_menu %}
+            {% sub_menu item template='menus/flat_menu_sub_menu.html' %}
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+</div>

--- a/core/templates/menus/flat_menu_sub_menu.html
+++ b/core/templates/menus/flat_menu_sub_menu.html
@@ -1,0 +1,14 @@
+{% load menu_tags %}
+
+{% if menu_items %}
+  <ul class="sub-menu-container menu-container">
+    {% for item in menu_items %}
+      <li class="menu-item {{ item.active_class }}{% if item.has_children_in_menu %} sub-menu{% endif %}">
+        <a class="menu-link" href="{{ item.href }}"><div>{{ item.text }}</div></a>
+        {% if item.has_children_in_menu %}
+          {% sub_menu item template='menus/flat_menu_sub_menu.html' %}
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+{% endif %}

--- a/indicator/templates/filters/scientific_production.html
+++ b/indicator/templates/filters/scientific_production.html
@@ -11,7 +11,7 @@
       <option value="document_type">{% trans "Document Type" %}</option>
       <option value="document_language">{% trans "Document Language" %}</option>
       <option value="open_access">{% trans "Open Access" %}</option>
-      <option value="access_type">{% trans "Access Type" %}</option>
+      <option value="open_access_status">{% trans "Access Type" %}</option>
       <option value="subject_area_level_0">{% trans "Domain" %}</option>
       <option value="subject_area_level_1">{% trans "Field" %}</option>
       <option value="subject_area_level_2">{% trans "Subfield" %}</option>

--- a/search_gateway/data_sources_with_settings.py
+++ b/search_gateway/data_sources_with_settings.py
@@ -155,7 +155,7 @@ DATA_SOURCES = {
             },
             "document_language": {
                 "index_field_name": "language",
-                "filter": {"size": 200, "order": {"_key": "asc"}},
+                "filter": {"size": 500, "order": {"_key": "asc"}},
                 "settings": {
                     "class_filter": "select2",
                     "label": _("Document Language"),


### PR DESCRIPTION
This pull request introduces significant improvements to the navigation menu, focusing on enhanced mobile menu usability, visual consistency, and support for deeper menu hierarchies. The main changes include a new mobile menu interaction logic, updates to the CSS for menu styling and structure, and the addition of custom menu templates to support up to four menu levels. There are also minor changes to filter naming and configuration in unrelated files.

**Mobile menu functionality and structure:**

* Added new JavaScript logic in `core/static/js/custom.js` to improve mobile menu usability, allowing submenu toggling by tapping on menu labels and synchronizing submenu states for a smoother accordion experience.
* Updated the menu rendering in `core/templates/include/header.html` to use custom templates (`menus/flat_menu.html`, `menus/flat_menu_sub_menu.html`) and support up to four menu levels for both mobile and desktop menus.
* Introduced new menu templates `core/templates/menus/flat_menu.html` and `core/templates/menus/flat_menu_sub_menu.html` to render nested menus consistently and flexibly. [[1]](diffhunk://#diff-3c23218be73791a5f8bf3da4dcc47fe069396e75b22ce293c534696a080046ccR1-R20) [[2]](diffhunk://#diff-14b82d00edcb9ecfd17b0b852700ac4943bfc45ec96a82c211ec03b4de8226d2R1-R14)

**Menu styling and visual consistency:**

* Refactored and expanded CSS in `core/static/css/custom.css` to support deeper menu hierarchies, unify text transformation (lowercase), improve submenu triggers, and enhance hover/focus states for both mobile and desktop menus. This includes restructuring selectors, adjusting paddings, and adding new styles for submenu containers and triggers. [[1]](diffhunk://#diff-842f79a07fc5a329560cc4c9babed68bb08a80825117a3d477ec52a5bfe0005aL185-R185) [[2]](diffhunk://#diff-842f79a07fc5a329560cc4c9babed68bb08a80825117a3d477ec52a5bfe0005aL206-R211) [[3]](diffhunk://#diff-842f79a07fc5a329560cc4c9babed68bb08a80825117a3d477ec52a5bfe0005aL226-R236) [[4]](diffhunk://#diff-842f79a07fc5a329560cc4c9babed68bb08a80825117a3d477ec52a5bfe0005aR245-R301) [[5]](diffhunk://#diff-842f79a07fc5a329560cc4c9babed68bb08a80825117a3d477ec52a5bfe0005aL404-R463) [[6]](diffhunk://#diff-842f79a07fc5a329560cc4c9babed68bb08a80825117a3d477ec52a5bfe0005aR529-R535) [[7]](diffhunk://#diff-842f79a07fc5a329560cc4c9babed68bb08a80825117a3d477ec52a5bfe0005aL480-R547) [[8]](diffhunk://#diff-842f79a07fc5a329560cc4c9babed68bb08a80825117a3d477ec52a5bfe0005aR557-R657)

**Minor unrelated changes:**

* Updated filter option naming in `indicator/templates/filters/scientific_production.html` to use `open_access_status` instead of `access_type`.
* Increased filter size in `search_gateway/data_sources_with_settings.py` for `document_language` from 200 to 500.