### PR TITLE
Corrige comportamento de controles de ranqueamento em página de periódico

### DIFF
--- a/indicator/journal_metrics/presentation.py
+++ b/indicator/journal_metrics/presentation.py
@@ -69,6 +69,11 @@ def build_profile_context(
     selected_year_metrics = {}
     profile_year_options = [resolved_publication_year] if resolved_publication_year else []
     profile_category_options = [resolved_category_id] if resolved_category_id else []
+    profile_category_level_options = [
+        str((option or {}).get("key") if isinstance(option, dict) else option).strip()
+        for option in (filters_data or {}).get("category_level", [])
+        if str((option or {}).get("key") if isinstance(option, dict) else option).strip()
+    ]
 
     if profile_data:
         journal_title = str(profile_data.get("journal_title") or "").strip()
@@ -92,6 +97,13 @@ def build_profile_context(
         )
         profile_year_options = list(reversed(available_years))
         profile_category_options = profile_data.get("available_categories") or []
+        available_category_levels = [
+            str(level).strip()
+            for level in (profile_data.get("available_category_levels") or [])
+            if str(level).strip()
+        ]
+        if available_category_levels:
+            profile_category_level_options = available_category_levels
 
     collection_display_value = _build_collection_display_value(profile_data, selected_year_metrics)
     profile_header_attributes = _build_profile_header_attributes(
@@ -159,6 +171,7 @@ def build_profile_context(
         "profile_kpis": profile_kpis,
         "profile_badges": profile_badges,
         "profile_year_options": profile_year_options,
+        "profile_category_level_options": profile_category_level_options,
         "profile_category_options": profile_category_options,
         "filters_data": filters_data or {},
     }

--- a/indicator/search/controller.py
+++ b/indicator/search/controller.py
@@ -7,6 +7,7 @@ from indicator.journal_metrics.config import (
     DEFAULT_MINIMUM_PUBLICATIONS,
     DEFAULT_PUBLICATION_YEAR,
     DEFAULT_RANKING_METRIC,
+    VALID_CATEGORY_LEVELS,
     get_index_field_name,
     normalize_category_level,
     normalize_minimum_publications,
@@ -31,6 +32,8 @@ CONTROL_FILTER_KEYS = {
     "return_study_unit",
     "csrfmiddlewaretoken",
 }
+
+CATEGORY_LEVEL_ORDER = tuple(level for level in ("domain", "field", "subfield", "topic") if level in VALID_CATEGORY_LEVELS)
 
 
 def _normalize_indicator_study_unit(study_unit):
@@ -119,6 +122,131 @@ def _build_journal_metrics_filter_clauses(form_filters, selected_category_level)
         return list(bool_query.get("must", [])), list(bool_query.get("must_not", []))
 
     return [], []
+
+
+def _strip_term_clause(clauses, field_name):
+    return [
+        clause
+        for clause in (clauses or [])
+        if not (
+            isinstance(clause, dict)
+            and isinstance(clause.get("term"), dict)
+            and field_name in clause.get("term", {})
+        )
+    ]
+
+
+def _list_available_category_levels(es, index_name, base_must, inherited_must_not):
+    body = {
+        "size": 0,
+        "query": {
+            "bool": {
+                "must": list(base_must),
+                **({"must_not": inherited_must_not} if inherited_must_not else {}),
+            }
+        },
+        "aggs": {
+            "category_levels": {
+                "terms": {
+                    "field": "category_level",
+                    "size": len(CATEGORY_LEVEL_ORDER) or len(VALID_CATEGORY_LEVELS),
+                }
+            }
+        },
+    }
+
+    try:
+        response = es.search(index=index_name, body=body)
+    except Exception:
+        return []
+
+    level_order = {level: index for index, level in enumerate(CATEGORY_LEVEL_ORDER)}
+    normalized_levels = []
+    for level in indicator_parser.parse_terms_agg_keys(response, "category_levels"):
+        normalized_level = str(level or "").strip().lower()
+        if normalized_level not in VALID_CATEGORY_LEVELS or normalized_level in normalized_levels:
+            continue
+        normalized_levels.append(normalized_level)
+
+    return sorted(normalized_levels, key=lambda level: level_order.get(level, len(level_order)))
+
+
+def _list_available_categories(es, index_name, base_must, selected_category_level, publication_year, inherited_must_not):
+    categories_must = list(base_must)
+    categories_must.append({"term": {"category_level": selected_category_level}})
+
+    if publication_year not in (None, ""):
+        try:
+            categories_year = int(publication_year)
+        except (TypeError, ValueError):
+            categories_year = publication_year
+        categories_must.append({"term": {"publication_year": categories_year}})
+
+    categories_body = {
+        "size": 0,
+        "query": {
+            "bool": {
+                "must": categories_must,
+                **({"must_not": inherited_must_not} if inherited_must_not else {}),
+            }
+        },
+        "aggs": {
+            "categories": {
+                "terms": {
+                    "field": "category_id",
+                    "size": 2000,
+                    "order": {"publications_total": "desc"},
+                },
+                "aggs": {
+                    "publications_total": {"sum": {"field": "journal_publications_count"}},
+                },
+            }
+        },
+    }
+
+    try:
+        response = es.search(index=index_name, body=categories_body)
+    except Exception:
+        return []
+
+    return indicator_parser.parse_terms_agg_keys(response, "categories")
+
+
+def _search_journal_metrics_profile_hits(
+    es,
+    index_name,
+    base_must,
+    selected_category_level,
+    selected_category_id,
+    inherited_must_not,
+):
+    data_must = list(base_must)
+    data_must.append({"term": {"category_level": selected_category_level}})
+    if selected_category_id:
+        data_must.append({"term": {"category_id": selected_category_id}})
+
+    body = {
+        "size": 1000,
+        "query": {
+            "bool": {
+                "must": data_must,
+                **({"must_not": inherited_must_not} if inherited_must_not else {}),
+            }
+        },
+        "sort": [
+            {"publication_year": {"order": "asc"}},
+            {get_index_field_name("journal_impact_cohort"): {"order": "desc", "missing": "_last"}},
+        ],
+        "collapse": {"field": "publication_year"},
+        "_source": indicator_query.JOURNAL_METRICS_SOURCE_FIELDS,
+    }
+
+    try:
+        response = es.search(index=index_name, body=body)
+    except Exception as e:
+        return None, f"Error executing search: {e}"
+
+    return response.get("hits", {}).get("hits", []), None
 
 
 def get_journal_metrics_data(form_filters):
@@ -214,6 +342,7 @@ def get_journal_metrics_timeseries(
         form_filters,
         selected_category_level,
     )
+    inherited_must = _strip_term_clause(inherited_must, "category_level")
 
     base_must = list(inherited_must)
     if issn:
@@ -221,77 +350,78 @@ def get_journal_metrics_timeseries(
     if journal:
         base_must.append({"term": {"journal_title": journal}})
 
-    categories_must = list(base_must)
-    categories_must.append({"term": {"category_level": selected_category_level}})
-
-    if publication_year not in (None, ""):
-        try:
-            categories_year = int(publication_year)
-        except (TypeError, ValueError):
-            categories_year = publication_year
-        categories_must.append({"term": {"publication_year": categories_year}})
-
-    categories_body = {
-        "size": 0,
-        "query": {
-            "bool": {
-                "must": categories_must,
-                **({"must_not": inherited_must_not} if inherited_must_not else {}),
-            }
-        },
-        "aggs": {
-            "categories": {
-                "terms": {
-                    "field": "category_id",
-                    "size": 2000,
-                    "order": {"publications_total": "desc"},
-                },
-                "aggs": {
-                    "publications_total": {"sum": {"field": "journal_publications_count"}},
-                },
-            }
-        },
-    }
+    available_category_levels = _list_available_category_levels(
+        es,
+        index_name,
+        base_must,
+        inherited_must_not,
+    )
+    if available_category_levels and selected_category_level not in available_category_levels:
+        selected_category_level = available_category_levels[0]
 
     selected_category_id = str(category_id).strip() if category_id not in (None, "") else None
-    available_categories = []
-    try:
-        categories_res = es.search(index=index_name, body=categories_body)
-        available_categories = indicator_parser.parse_terms_agg_keys(categories_res, "categories")
-        if selected_category_id and selected_category_id not in available_categories:
-            selected_category_id = None
-        if not selected_category_id and available_categories:
-            selected_category_id = available_categories[0]
-    except Exception:
-        available_categories = []
+    available_categories = _list_available_categories(
+        es,
+        index_name,
+        base_must,
+        selected_category_level,
+        publication_year,
+        inherited_must_not,
+    )
+    if selected_category_id and selected_category_id not in available_categories:
+        selected_category_id = None
+    if not selected_category_id and available_categories:
+        selected_category_id = available_categories[0]
 
-    data_must = list(base_must)
-    data_must.append({"term": {"category_level": selected_category_level}})
-    if selected_category_id:
-        data_must.append({"term": {"category_id": selected_category_id}})
+    hits, search_error = _search_journal_metrics_profile_hits(
+        es,
+        index_name,
+        base_must,
+        selected_category_level,
+        selected_category_id,
+        inherited_must_not,
+    )
+    if search_error:
+        return None, search_error
 
-    body = {
-        "size": 1000,
-        "query": {
-            "bool": {
-                "must": data_must,
-                **({"must_not": inherited_must_not} if inherited_must_not else {}),
-            }
-        },
-        "sort": [
-            {"publication_year": {"order": "asc"}},
-            {get_index_field_name("journal_impact_cohort"): {"order": "desc", "missing": "_last"}},
-        ],
-        "collapse": {"field": "publication_year"},
-        "_source": indicator_query.JOURNAL_METRICS_SOURCE_FIELDS,
-    }
+    if not hits and available_category_levels:
+        for fallback_category_level in available_category_levels:
+            if fallback_category_level == selected_category_level:
+                continue
 
-    try:
-        res = es.search(index=index_name, body=body)
-    except Exception as e:
-        return None, f"Error executing search: {e}"
+            fallback_available_categories = _list_available_categories(
+                es,
+                index_name,
+                base_must,
+                fallback_category_level,
+                publication_year,
+                inherited_must_not,
+            )
+            fallback_selected_category_id = selected_category_id
+            if fallback_selected_category_id and fallback_selected_category_id not in fallback_available_categories:
+                fallback_selected_category_id = None
+            if not fallback_selected_category_id and fallback_available_categories:
+                fallback_selected_category_id = fallback_available_categories[0]
 
-    hits = res.get("hits", {}).get("hits", [])
+            fallback_hits, search_error = _search_journal_metrics_profile_hits(
+                es,
+                index_name,
+                base_must,
+                fallback_category_level,
+                fallback_selected_category_id,
+                inherited_must_not,
+            )
+            if search_error:
+                return None, search_error
+            if not fallback_hits:
+                continue
+
+            selected_category_level = fallback_category_level
+            selected_category_id = fallback_selected_category_id
+            available_categories = fallback_available_categories
+            hits = fallback_hits
+            break
+
     if not hits:
         return None, "Not found"
 
@@ -340,6 +470,7 @@ def get_journal_metrics_timeseries(
         category_spider = []
 
     parsed["available_categories"] = available_categories
+    parsed["available_category_levels"] = available_category_levels or [selected_category_level]
     parsed["selected_category_id"] = selected_category_id
     parsed["selected_category_level"] = selected_category_level
     parsed["category_publications_spider"] = category_spider

--- a/indicator/templates/journal_profile.html
+++ b/indicator/templates/journal_profile.html
@@ -72,11 +72,11 @@
           <div class="journal-profile-controls-bar__field">
             <label class="form-label mb-1" for="journal-profile-category-level-select">{% trans "Category Type" %}</label>
             <select id="journal-profile-category-level-select" class="form-select" name="category_level" data-profile-category-level>
-              {% if not filters_data.category_level %}
+              {% if not profile_category_level_options %}
               <option value="{{ selected_category_level }}" selected>{{ selected_category_level|ui_value:"category_level" }}</option>
               {% endif %}
-              {% for option in filters_data.category_level %}
-              <option value="{{ option.key }}" {% if selected_category_level == option.key|stringformat:'s' %}selected{% endif %}>{{ option.key|ui_value:"category_level" }}</option>
+              {% for option in profile_category_level_options %}
+              <option value="{{ option }}" {% if selected_category_level == option|stringformat:'s' %}selected{% endif %}>{{ option|ui_value:"category_level" }}</option>
               {% endfor %}
             </select>
           </div>

--- a/indicator/tests/test_journal_metrics_controller.py
+++ b/indicator/tests/test_journal_metrics_controller.py
@@ -47,6 +47,14 @@ def _patch_journal_metrics_dependencies(monkeypatch, client):
     )
     monkeypatch.setattr(
         search_controller.data_sources_with_settings,
+        "get_field_settings",
+        lambda _data_source: {
+            "category_id": {"index_field_name": "category_id"},
+            "category_level": {"index_field_name": "category_level"},
+        },
+    )
+    monkeypatch.setattr(
+        search_controller.data_sources_with_settings,
         "get_query_operator_fields",
         lambda _data_source: set(),
     )
@@ -139,3 +147,89 @@ def test_build_journal_metrics_profile_context_uses_profile_data_defaults():
     assert profile_context["selected_publication_year"] == "2021"
     assert profile_context["profile_year_options"] == ["2021", "2020"]
     assert profile_context["profile_category_options"] == ["Health", "Policy"]
+
+
+class JournalProfileFallbackClient:
+    def __init__(self):
+        self.calls = []
+
+    def search(self, index, body):
+        self.calls.append({"index": index, "body": body})
+        aggs = body.get("aggs", {})
+        must_clauses = body.get("query", {}).get("bool", {}).get("must", [])
+        category_level = next(
+            (
+                clause.get("term", {}).get("category_level")
+                for clause in must_clauses
+                if "term" in clause and "category_level" in clause.get("term", {})
+            ),
+            None,
+        )
+
+        if "category_levels" in aggs:
+            return {
+                "aggregations": {
+                    "category_levels": {
+                        "buckets": [{"key": "field", "doc_count": 3}],
+                    }
+                }
+            }
+
+        if "categories" in aggs:
+            buckets = [{"key": "Health", "doc_count": 3}] if category_level == "field" else []
+            return {
+                "aggregations": {
+                    "categories": {
+                        "buckets": buckets,
+                    }
+                }
+            }
+
+        if "by_category" in aggs:
+            return {
+                "aggregations": {
+                    "by_category": {
+                        "buckets": [],
+                    }
+                }
+            }
+
+        if category_level == "field":
+            return {
+                "hits": {
+                    "hits": [
+                        {
+                            "_source": {
+                                "journal_title": "Journal A",
+                                "journal_issn": "1234-5678",
+                                "publication_year": 2020,
+                                "category_level": "field",
+                                "category_id": "Health",
+                                "journal_publications_count": 10,
+                                "journal_citations_total": 20,
+                                "journal_citations_mean": 2.0,
+                                "journal_impact_cohort": 1.5,
+                            }
+                        }
+                    ]
+                }
+            }
+
+        return {"hits": {"hits": []}}
+
+
+def test_get_journal_metrics_timeseries_falls_back_to_available_category_level(monkeypatch):
+    client = JournalProfileFallbackClient()
+    _patch_journal_metrics_dependencies(monkeypatch, client)
+
+    profile_data, error = search_controller.get_journal_metrics_timeseries(
+        issn="1234-5678",
+        category_level="topic",
+        publication_year="2020",
+        form_filters={},
+    )
+
+    assert error is None
+    assert profile_data["selected_category_level"] == "field"
+    assert profile_data["available_category_levels"] == ["field"]
+    assert profile_data["selected_category_id"] == "Health"


### PR DESCRIPTION
This pull request introduces significant improvements to how journal metrics profiles handle category levels, including fallback logic for unavailable category levels, expanded API support, and updates to presentation and tests. The main changes are grouped below by theme.

**Category Level Handling and Fallback Logic**

* Added `_list_available_category_levels`, `_list_available_categories`, and `_search_journal_metrics_profile_hits` helper functions to modularize and simplify the retrieval of available category levels and categories, and to handle search hits for journal metrics profiles.
* Updated `get_journal_metrics_timeseries` to automatically fall back to the next available category level if the requested one is unavailable, ensuring users always receive results when possible.
* Ensured the returned profile data includes `available_category_levels` and that selection logic is robust against missing or invalid category levels.

**Presentation and Template Updates**

* Modified `build_profile_context` in `presentation.py` to support and propagate `profile_category_level_options`, sourced from both filters and profile data, so that templates can display the correct category level options. [[1]](diffhunk://#diff-f568251f8327be4fa7149b9fb57955a0132c8e4d31affe968a82dab2d0c0ab6eR72-R76) [[2]](diffhunk://#diff-f568251f8327be4fa7149b9fb57955a0132c8e4d31affe968a82dab2d0c0ab6eR100-R106) [[3]](diffhunk://#diff-f568251f8327be4fa7149b9fb57955a0132c8e4d31affe968a82dab2d0c0ab6eR174)
* Updated `journal_profile.html` template to use `profile_category_level_options` for rendering the category level dropdown, improving UI consistency and correctness.

**Testing Enhancements**

* Added new tests to verify fallback logic for category levels, including a mock client and assertions that the fallback operates as intended when requested category levels are missing.
* Updated test setup to patch new dependencies and ensure correct field settings for category level and category ID.

**Constants and Internal Utilities**

* Introduced `CATEGORY_LEVEL_ORDER` constant and imported `VALID_CATEGORY_LEVELS` to ensure category levels are handled in a consistent, ordered manner. [[1]](diffhunk://#diff-83b13ef568e885824ea8fb8b519b88efe9fb5a9ed920cddd08cb7819c2c8207dR10) [[2]](diffhunk://#diff-83b13ef568e885824ea8fb8b519b88efe9fb5a9ed920cddd08cb7819c2c8207dR36-R37)
* Added `_strip_term_clause` utility to clean up search queries by removing unwanted term clauses for specific fields.

These changes collectively improve the robustness, usability, and maintainability of the journal metrics profile feature, especially in scenarios where certain category levels may be missing from the dataset.