### PR TITLE
Evita que params indevidos sejam passados à rota journal metrics

### DIFF
--- a/indicator/journal_metrics/params.py
+++ b/indicator/journal_metrics/params.py
@@ -16,6 +16,7 @@ ISSN_PATTERN = re.compile(r"^\d{4}-[\dXx]{4}$")
 
 PROFILE_ROUTE_PARAM_KEYS = {"issn", "journal", "journal_issn", "journal_title"}
 PROFILE_QUERY_PARAM_KEYS = ("collection", "publication_year", "category_level", "category_id")
+PROFILE_PASSTHROUGH_PARAM_KEYS = {"collection"}
 PROFILE_NON_FILTER_KEYS = PROFILE_ROUTE_PARAM_KEYS | {
     "category_id",
     "category_level",
@@ -63,7 +64,6 @@ def build_profile_url(params, issn):
     query_params["journal"] = str(issn).strip()
 
     source_items = list(source_params.lists()) if hasattr(source_params, "lists") else list(dict(source_params).items())
-    appended_keys = set()
 
     for key in PROFILE_QUERY_PARAM_KEYS:
         for source_key, source_values in source_items:
@@ -73,20 +73,7 @@ def build_profile_url(params, issn):
             values = source_values if isinstance(source_values, (list, tuple)) else [source_values]
             for value in values:
                 query_params.appendlist(key, value)
-            appended_keys.add(key)
             break
-
-    if hasattr(source_params, "lists"):
-        for key, values in source_params.lists():
-            if key in appended_keys:
-                continue
-            for value in values:
-                query_params.appendlist(key, value)
-    else:
-        for key, value in dict(source_params).items():
-            if key in appended_keys:
-                continue
-            query_params[key] = value
 
     query_string = query_params.urlencode()
     return f"{redirect_url}?{query_string}" if query_string else redirect_url
@@ -120,9 +107,9 @@ def normalize_request_filters(filters, source_filters=None, clean=False):
 
 def extract_profile_passthrough_filters(filters):
     return {
-        key: value
-        for key, value in search_utils.clean_form_filters(dict(filters or {})).items()
-        if key not in PROFILE_NON_FILTER_KEYS
+        key: str(filters.get(key) or "").strip()
+        for key in PROFILE_PASSTHROUGH_PARAM_KEYS
+        if str(filters.get(key) or "").strip()
     }
 
 

--- a/indicator/journal_metrics/params.py
+++ b/indicator/journal_metrics/params.py
@@ -10,7 +10,7 @@ from .config import (
     normalize_minimum_publications,
     normalize_ranking_metric,
 )
-from ..search import utils as search_utils
+from indicator.search.utils import clean_form_filters
 
 ISSN_PATTERN = re.compile(r"^\d{4}-[\dXx]{4}$")
 
@@ -37,7 +37,6 @@ RANKING_CONFIGURATION_KEYS = {
     "category_id",
     "minimum_publications",
 }
-TIMESERIES_NON_FILTER_KEYS = PROFILE_NON_FILTER_KEYS | {"minimum_publications"}
 
 
 def looks_like_issn(value):
@@ -54,16 +53,10 @@ def get_profile_issn(params, issn=None):
 
 def build_profile_url(params, issn):
     redirect_url = reverse("indicator_journal_metrics")
-    source_params = params.copy()
-
-    for key in PROFILE_ROUTE_PARAM_KEYS:
-        if key in source_params:
-            source_params.pop(key)
-
     query_params = QueryDict("", mutable=True)
     query_params["journal"] = str(issn).strip()
 
-    source_items = list(source_params.lists()) if hasattr(source_params, "lists") else list(dict(source_params).items())
+    source_items = list(params.lists()) if hasattr(params, "lists") else list(dict(params or {}).items())
 
     for key in PROFILE_QUERY_PARAM_KEYS:
         for source_key, source_values in source_items:
@@ -80,7 +73,7 @@ def build_profile_url(params, issn):
 
 
 def normalize_request_filters(filters, source_filters=None, clean=False):
-    normalized_filters = search_utils.clean_form_filters(dict(filters or {})) if clean else dict(filters or {})
+    normalized_filters = clean_form_filters(dict(filters or {})) if clean else dict(filters or {})
     source_filters = source_filters if source_filters is not None else filters or {}
 
     for key in ("scope", "return_study_unit", "study_unit"):
@@ -120,7 +113,7 @@ def build_timeseries_request(params):
         issn = journal_param
 
     form_filters = dict(params or {})
-    for key in TIMESERIES_NON_FILTER_KEYS:
+    for key in PROFILE_NON_FILTER_KEYS:
         form_filters.pop(key, None)
 
     return {
@@ -128,5 +121,5 @@ def build_timeseries_request(params):
         "category_id": params.get("category_id"),
         "category_level": params.get("category_level"),
         "publication_year": params.get("publication_year"),
-        "form_filters": search_utils.clean_form_filters(form_filters),
+        "form_filters": clean_form_filters(form_filters),
     }

--- a/indicator/journal_metrics/presentation.py
+++ b/indicator/journal_metrics/presentation.py
@@ -17,8 +17,9 @@ def build_ranking_context(applied_filters, ranking_data):
     if ranking_data:
         passthrough_filters = {
             key: value
-            for key, value in (applied_filters or {}).items()
-            if key not in params.PROFILE_NON_FILTER_KEYS and value not in (None, "")
+            for key in params.PROFILE_PASSTHROUGH_PARAM_KEYS
+            for value in [(applied_filters or {}).get(key)]
+            if value not in (None, "")
         }
         ranking_publication_year = ranking_data.get("year") or applied_filters.get("publication_year")
 

--- a/indicator/tests/test_journal_metrics_controller.py
+++ b/indicator/tests/test_journal_metrics_controller.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.http import QueryDict
 
 if not settings.configured:
     settings.configure(
@@ -119,6 +120,41 @@ def test_normalize_journal_metrics_request_filters_applies_defaults():
     assert normalized_filters["category_level"] == journal_metrics_config.DEFAULT_CATEGORY_LEVEL
     assert normalized_filters["category_id"] == journal_metrics_config.DEFAULT_CATEGORY_ID
     assert normalized_filters["minimum_publications"] == str(journal_metrics_config.DEFAULT_MINIMUM_PUBLICATIONS)
+
+
+def test_build_profile_url_keeps_only_profile_query_params(monkeypatch):
+    querydict = QueryDict("", mutable=True)
+    querydict["collection"] = "scl"
+    querydict["publication_year"] = "2022"
+    querydict["category_level"] = "field"
+    querydict["category_id"] = "Social Sciences"
+    querydict["country"] = "Brazil"
+    querydict["is_scielo"] = "No"
+
+    monkeypatch.setattr(
+        journal_metrics_params,
+        "reverse",
+        lambda _name: "/indicators/journal-metrics/",
+    )
+
+    profile_url = journal_metrics_params.build_profile_url(querydict, "1809-4031")
+
+    assert profile_url == (
+        "/indicators/journal-metrics/"
+        "?journal=1809-4031&collection=scl&publication_year=2022"
+        "&category_level=field&category_id=Social+Sciences"
+    )
+
+
+def test_extract_profile_passthrough_filters_keeps_only_collection():
+    querydict = QueryDict("", mutable=True)
+    querydict["collection"] = "scl"
+    querydict["country"] = "Brazil"
+    querydict["is_scielo"] = "No"
+
+    filters = journal_metrics_params.extract_profile_passthrough_filters(querydict)
+
+    assert filters == {"collection": "scl"}
 
 
 def test_build_journal_metrics_profile_context_uses_profile_data_defaults():


### PR DESCRIPTION
This pull request refactors how filter parameters are handled in the journal metrics module, focusing on stricter control of which parameters are passed through and used in profile and ranking contexts. It also improves the test coverage for these changes. The main improvements are the introduction of `PROFILE_PASSTHROUGH_PARAM_KEYS`, simplification of filter extraction, and updates to related logic and tests.

Parameter handling and filtering improvements:

* Introduced `PROFILE_PASSTHROUGH_PARAM_KEYS` to explicitly define which parameters (currently only `collection`) are allowed to pass through for profile-related operations, replacing broader filter logic. (`indicator/journal_metrics/params.py`)
* Refactored `extract_profile_passthrough_filters` to only include keys listed in `PROFILE_PASSTHROUGH_PARAM_KEYS`, ensuring unwanted parameters are excluded. (`indicator/journal_metrics/params.py`)
* Updated `build_profile_url` and `build_ranking_context` to use the new passthrough keys, ensuring only relevant query parameters are included in URLs and ranking contexts. (`indicator/journal_metrics/params.py`, `indicator/journal_metrics/presentation.py`) [[1]](diffhunk://#diff-70907e4dba3b64149e65467beb3bd2f3505d99417d5278d97e9820cbcc14b6f4L56-R59) [[2]](diffhunk://#diff-f568251f8327be4fa7149b9fb57955a0132c8e4d31affe968a82dab2d0c0ab6eL20-R22)

Code simplification and consistency:

* Removed unnecessary intermediate variables and redundant logic in `build_profile_url`, and consolidated filter cleaning to use the new import. (`indicator/journal_metrics/params.py`) [[1]](diffhunk://#diff-70907e4dba3b64149e65467beb3bd2f3505d99417d5278d97e9820cbcc14b6f4L56-R59) [[2]](diffhunk://#diff-70907e4dba3b64149e65467beb3bd2f3505d99417d5278d97e9820cbcc14b6f4L76-R76) [[3]](diffhunk://#diff-70907e4dba3b64149e65467beb3bd2f3505d99417d5278d97e9820cbcc14b6f4L136-R124)

Test coverage enhancements:

* Added new tests to verify that only allowed parameters are included in profile URLs and passthrough filters, improving reliability and correctness. (`indicator/tests/test_journal_metrics_controller.py`)

These changes make parameter handling more predictable and secure, and the added tests help ensure the new logic works as intended.