### PR TITLE
Add migration core 003

### DIFF
--- a/core/migrations/0003_samenu_samenuitem.py
+++ b/core/migrations/0003_samenu_samenuitem.py
@@ -8,7 +8,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("core", "0002_language"),
-        ("wagtailcore", "0096_referenceindex_referenceindex_source_object_and_more"),
     ]
 
     operations = [

--- a/core/migrations/0003_samenu_samenuitem.py
+++ b/core/migrations/0003_samenu_samenuitem.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("core", "0003_alter_language_options_alter_language_code2_and_more"),
+        ("core", "0002_language"),
         ("wagtailcore", "0096_referenceindex_referenceindex_source_object_and_more"),
     ]
 

--- a/core/migrations/0004_samenu_samenuitem.py
+++ b/core/migrations/0004_samenu_samenuitem.py
@@ -1,0 +1,127 @@
+import django.db.models.deletion
+import modelcluster.fields
+import uuid
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0003_alter_language_options_alter_language_code2_and_more"),
+        ("wagtailcore", "0096_referenceindex_referenceindex_source_object_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SAMenu",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("translation_key", models.UUIDField(default=uuid.uuid4, editable=False)),
+                (
+                    "locale",
+                    models.ForeignKey(
+                        editable=False,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="wagtailcore.locale",
+                        verbose_name="locale",
+                    ),
+                ),
+                ("title", models.CharField(max_length=255)),
+                ("handle", models.CharField(default="analytics", max_length=100)),
+                ("short_name", models.CharField(blank=True, max_length=100)),
+                ("is_active", models.BooleanField(default=True)),
+            ],
+            options={
+                "verbose_name": "SciELO Analytics menu",
+                "verbose_name_plural": "SciELO Analytics menus",
+                "unique_together": {("translation_key", "locale")},
+            },
+        ),
+        migrations.CreateModel(
+            name="SAMenuItem",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("sort_order", models.IntegerField(blank=True, editable=False, null=True)),
+                ("label", models.CharField(max_length=255)),
+                ("short_label", models.CharField(blank=True, max_length=100)),
+                (
+                    "item_type",
+                    models.CharField(
+                        choices=[("page", "Page"), ("url", "URL"), ("anchor", "Anchor")],
+                        default="page",
+                        max_length=20,
+                    ),
+                ),
+                ("link_url", models.CharField(blank=True, max_length=500)),
+                ("link_anchor", models.CharField(blank=True, max_length=255)),
+                ("allow_subnav", models.BooleanField(default=False)),
+                ("open_in_new_tab", models.BooleanField(default=False)),
+                ("is_visible", models.BooleanField(default=True)),
+                ("icon_key", models.CharField(blank=True, max_length=100)),
+                ("icon_svg", models.TextField(blank=True)),
+                (
+                    "link_page",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailcore.page",
+                    ),
+                ),
+                (
+                    "menu",
+                    modelcluster.fields.ParentalKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="menu_items",
+                        to="core.samenu",
+                    ),
+                ),
+                (
+                    "parent",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="child_menu_items",
+                        to="core.samenuitem",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "SciELO Analytics menu item",
+                "verbose_name_plural": "SciELO Analytics menu items",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="samenu",
+            constraint=models.UniqueConstraint(
+                fields=("locale", "handle"),
+                name="core_samenu_unique_handle_locale",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="samenuitem",
+            constraint=models.CheckConstraint(
+                condition=~models.Q(parent=models.F("pk")),
+                name="core_samenuitem_parent_not_self",
+            ),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -222,7 +222,7 @@ class SAMenuItem(Orderable):
         verbose_name_plural = _("SciELO Analytics menu items")
         constraints = [
             models.CheckConstraint(
-                check=~Q(parent=models.F("pk")),
+                condition=~Q(parent=models.F("pk")),
                 name="core_samenuitem_parent_not_self",
             ),
         ]

--- a/core/models.py
+++ b/core/models.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.db.models import Q
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from wagtail.admin.panels import FieldPanel, InlinePanel
@@ -133,8 +133,8 @@ class SAMenu(TranslatableMixin, ClusterableModel):
     ]
 
     class Meta(TranslatableMixin.Meta):
-        verbose_name = "SciELO Analytics menu"
-        verbose_name_plural = "SciELO Analytics menus"
+        verbose_name = _("SciELO Analytics menu")
+        verbose_name_plural = _("SciELO Analytics menus")
         constraints = [
             models.UniqueConstraint(
                 fields=["locale", "handle"],
@@ -172,9 +172,9 @@ class SAMenu(TranslatableMixin, ClusterableModel):
 
 class SAMenuItem(Orderable):
     class ItemType(models.TextChoices):
-        PAGE = "page", "Page"
-        URL = "url", "URL"
-        ANCHOR = "anchor", "Anchor"
+        PAGE = "page", _("Page")
+        URL = "url", _("URL")
+        ANCHOR = "anchor", _("Anchor")
 
     menu = ParentalKey("core.SAMenu", on_delete=models.CASCADE, related_name="menu_items")
     parent = models.ForeignKey(
@@ -218,8 +218,8 @@ class SAMenuItem(Orderable):
     ]
 
     class Meta:
-        verbose_name = "SciELO Analytics menu item"
-        verbose_name_plural = "SciELO Analytics menu items"
+        verbose_name = _("SciELO Analytics menu item")
+        verbose_name_plural = _("SciELO Analytics menu items")
         constraints = [
             models.CheckConstraint(
                 check=~Q(parent=models.F("pk")),

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -2,7 +2,7 @@
 
 from django.templatetags.static import static
 from django.utils.html import format_html
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet


### PR DESCRIPTION
#### O que esse PR faz?
- Adiciona migração para modelos SAMenu e SAMenuItem.
- Corrige uso de param que será legado a partir de Django 6
- Troca gettext por gettext_lazy em core/models.py

#### Onde a revisão poderia começar?
A partir do primeiro commit.

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A