### PR TITLE
Melhora tela que mostra resultados não encontrados

### DIFF
--- a/search/static/search/css/custom.css
+++ b/search/static/search/css/custom.css
@@ -711,6 +711,57 @@
   line-height: 1;
 }
 
+.results-empty {
+  margin-bottom: 1.85rem;
+}
+
+.results-empty__card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 23.5rem;
+  padding: 3rem 1.9rem 3.2rem;
+  border: 1px solid #dfe7f0;
+  border-radius: 6px;
+  background: #ffffff;
+  box-shadow: 0 8px 22px rgba(20, 38, 64, 0.05);
+  text-align: center;
+}
+
+.results-empty__icon {
+  width: 6.35rem;
+  height: 6.35rem;
+  margin-bottom: 1.7rem;
+  border-radius: 999px;
+  background-color: #f5f8fc;
+  background-image:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 24 24' fill='none' stroke='%2394A3B8' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='7'/%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 3rem 3rem;
+}
+
+.results-empty__content {
+  width: 100%;
+  max-width: 43rem;
+}
+
+.results-empty__title {
+  margin: 0;
+  color: #153b73;
+  font-size: 1.8rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.results-empty__description {
+  margin: 1.15rem auto 0;
+  color: #60799a;
+  font-size: 1.02rem;
+  line-height: 1.6;
+}
+
 .results-list {
   display: flex;
   flex-direction: column;
@@ -1312,6 +1363,27 @@
     flex-direction: column;
     align-items: stretch;
     margin-bottom: 1.6rem;
+  }
+
+  .results-empty__icon {
+    width: 5.1rem;
+    height: 5.1rem;
+    margin-bottom: 1.2rem;
+    background-size: 2.6rem 2.6rem;
+  }
+
+  .results-empty__card {
+    min-height: 18rem;
+    padding: 2.2rem 1.15rem 2.35rem;
+    border-radius: 4px;
+  }
+
+  .results-empty__title {
+    font-size: 1.45rem;
+  }
+
+  .results-empty__description {
+    font-size: 0.94rem;
   }
 
   .results-pagination__center {

--- a/search/templates/search/include/no_results.html
+++ b/search/templates/search/include/no_results.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+
+<section class="results-empty" aria-labelledby="results-empty-title">
+    <article class="results-empty__card">
+        <div class="results-empty__icon" aria-hidden="true"></div>
+        <div class="results-empty__content">
+            <h2 id="results-empty-title" class="results-empty__title">
+                {% trans "Nenhum resultado encontrado" %}
+            </h2>
+            <p class="results-empty__description">
+                {% trans "Não encontramos itens que correspondam aos termos e filtros aplicados nesta busca." %}
+            </p>
+        </div>
+    </article>
+</section>

--- a/search/templates/search/include/results.html
+++ b/search/templates/search/include/results.html
@@ -1,7 +1,0 @@
-<div id="results-container" class="sg-layout__results-offset">
-    {% if results_data.search_results %}
-        {% include "search/include/results_list.html" %}
-    {% else %}
-        {% include "search/include/no_results.html" %}
-    {% endif %}
-</div>

--- a/search/templates/search/include/results.html
+++ b/search/templates/search/include/results.html
@@ -1,10 +1,7 @@
-{% load humanize %}
-{% load static %}
-{% load i18n %}
-{% load wagtailsettings_tags %}
-{% load wagtailcore_tags %}
-
-
 <div id="results-container" class="sg-layout__results-offset">
-    {% include "search/include/results_list.html" %}
+    {% if results_data.search_results %}
+        {% include "search/include/results_list.html" %}
+    {% else %}
+        {% include "search/include/no_results.html" %}
+    {% endif %}
 </div>

--- a/search/templates/search/include/results_list.html
+++ b/search/templates/search/include/results_list.html
@@ -1,6 +1,7 @@
 {% load humanize %}
 {% load i18n %}
 
+{% if results_data.search_results %}
 <div id="results-count" class="mb-3">
     {% with total_count=results_data.total_results|default:"0" %}
     <div class="results-toolbar">
@@ -159,4 +160,7 @@
         <span class="results-pagination__nav-arrow" aria-hidden="true">&rsaquo;</span>
     </button>
 </div>
+{% endif %}
+{% else %}
+    {% include "search/include/no_results.html" %}
 {% endif %}

--- a/search/templates/search/search_page.html
+++ b/search/templates/search/search_page.html
@@ -83,7 +83,9 @@
 {% endblock %}
 
 {% block search_content %}
-    {% include "search/include/results.html" %}
+    <div id="results-container" class="sg-layout__results-offset">
+        {% include "search/include/results_list.html" %}
+    </div>
 {% endblock %}
 
 {% block extra_css %}


### PR DESCRIPTION
#### O que esse PR faz?

Este PR adiciona um estado visual de **“nenhum resultado encontrado”** para a interface de busca. A ideia é melhorar a experiência do usuário quando a pesquisa não retorna itens, exibindo uma mensagem clara e um card dedicado, em vez de deixar a área de resultados vazia ou ambígua.

#### Onde a revisão poderia começar?

A revisão pode começar por estes arquivos:

* `search/templates/search/include/no_results.html`
* `search/templates/search/include/results.html`
* `search/static/search/css/custom.css`

#### Como este poderia ser testado manualmente?

1. Abrir a interface de busca.
2. Realizar uma pesquisa com um termo que não retorne resultados.
3. Verificar se o card de “nenhum resultado encontrado” é exibido corretamente.
4. Confirmar se a mensagem, o ícone e o espaçamento estão adequados.
5. Validar o comportamento em diferentes tamanhos de tela, especialmente em mobile.

#### Algum cenário de contexto que queira dar?

Antes desta alteração, quando a busca não retornava resultados, a interface não deixava tão claro para o usuário que simplesmente não havia itens compatíveis com os filtros ou termos aplicados. Este ajuste torna esse estado mais explícito e melhora a comunicação visual da tela de resultados.

### Screenshots
<img width="2008" height="1202" alt="image" src="https://github.com/user-attachments/assets/38ebbede-c86c-473b-985b-119d530ec636" />


#### Quais são tickets relevantes?
N/A

### Referências
N/A