### PR TITLE
Adiciona as dimensões para a produção social

### DIFF
--- a/observation/management/commands/seed_observation_dimensions.py
+++ b/observation/management/commands/seed_observation_dimensions.py
@@ -3,50 +3,83 @@ from django.core.management.base import BaseCommand, CommandError
 from observation.models import ObservationDimension, ObservationPage
 
 
-DIMENSION_SPECS = [
-    {
-        "slug": "documents-by-institution",
-        "menu_label": "Evolution of Scientific Production - World - number of documents by Institution",
-        "row_label": "Institution",
-        "row_field_candidates": ["institutions", "institution"],
-        "is_default": False,
-    },
-    {
-        "slug": "documents-by-journal",
-        "menu_label": "Evolution of Scientific Production - World - number of documents by Journal",
-        "row_label": "Journal",
-        "row_field_candidates": ["source_name", "journal_title", "primary_source_title"],
-        "is_default": False,
-    },
-    {
-        "slug": "documents-by-thematic-area",
-        "menu_label": "Evolution of Scientific Production - World - number of documents by Thematic Area",
-        "row_label": "Thematic Area",
-        "row_field_candidates": ["subject_area_level_1", "topic_fields", "primary_topic_field"],
-        "is_default": False,
-    },
-    {
-        "slug": "documents-by-type-of-access",
-        "menu_label": "Evolution of Scientific Production - World - number of documents by Type of Access",
-        "row_label": "Type of Access",
-        "row_field_candidates": ["open_access_status", "open_access"],
-        "is_default": False,
-    },
-    {
-        "slug": "documents-by-publisher",
-        "menu_label": "Evolution of Scientific Production - World - number of documents by Publisher",
-        "row_label": "Publisher",
-        "row_field_candidates": ["publisher"],
-        "is_default": False,
-    },
-    {
-        "slug": "documents-by-country-region-affiliation",
-        "menu_label": "Evolution of Scientific Production - World - number of documents by Country and Region of Affiliation",
-        "row_label": "Country and Region of Affiliation",
-        "row_field_candidates": ["country", "author_country_codes"],
-        "is_default": True,
-    },
-]
+DIMENSION_SPECS_BY_INDEX = {
+    "scientific_production": [
+        {
+            "slug": "documents-by-institution",
+            "menu_label": "Evolution of Scientific Production - World - number of documents by Institution",
+            "row_label": "Institution",
+            "row_field_candidates": ["institutions", "institution"],
+            "is_default": False,
+        },
+        {
+            "slug": "documents-by-journal",
+            "menu_label": "Evolution of Scientific Production - World - number of documents by Journal",
+            "row_label": "Journal",
+            "row_field_candidates": ["source_name", "journal_title", "primary_source_title"],
+            "is_default": False,
+        },
+        {
+            "slug": "documents-by-thematic-area",
+            "menu_label": "Evolution of Scientific Production - World - number of documents by Thematic Area",
+            "row_label": "Thematic Area",
+            "row_field_candidates": ["subject_area_level_1", "topic_fields", "primary_topic_field"],
+            "is_default": False,
+        },
+        {
+            "slug": "documents-by-type-of-access",
+            "menu_label": "Evolution of Scientific Production - World - number of documents by Type of Access",
+            "row_label": "Type of Access",
+            "row_field_candidates": ["open_access_status", "open_access"],
+            "is_default": False,
+        },
+        {
+            "slug": "documents-by-publisher",
+            "menu_label": "Evolution of Scientific Production - World - number of documents by Publisher",
+            "row_label": "Publisher",
+            "row_field_candidates": ["publisher"],
+            "is_default": False,
+        },
+        {
+            "slug": "documents-by-country-region-affiliation",
+            "menu_label": "Evolution of Scientific Production - World - number of documents by Country and Region of Affiliation",
+            "row_label": "Country and Region of Affiliation",
+            "row_field_candidates": ["country", "author_country_codes"],
+            "is_default": True,
+        },
+    ],
+    "social_production": [
+        {
+            "slug": "documents-by-events",
+            "menu_label": "Brazil - Social Production - Country - Documents - Events",
+            "row_label": "Types",
+            "row_field_candidates": ["directory_type", "type"],
+            "is_default": True,
+        },
+        {
+            "slug": "documents-by-institutions",
+            "menu_label": "Brazil - Social Production - Country - Documents - Institutions",
+            "row_label": "Institutions",
+            "row_field_candidates": ["institutions"],
+            "is_default": False,
+        },
+        {
+            "slug": "documents-by-states",
+            "menu_label": "Brazil - Social Production - Country - Documents - States",
+            "row_label": "States",
+            "row_field_candidates": ["states"],
+            "is_default": False,
+        },
+        {
+            "slug": "documents-by-regions",
+            "menu_label": "Brazil - Social Production - Country - Documents - Regions",
+            "row_label": "Regions",
+            "row_field_candidates": ["regions"],
+            "row_field_fallback": "regions",
+            "is_default": False,
+        },
+    ],
+}
 
 
 class Command(BaseCommand):
@@ -102,8 +135,14 @@ class Command(BaseCommand):
         created_or_updated = 0
         default_slug = None
 
-        for spec in DIMENSION_SPECS:
+        dimension_specs = DIMENSION_SPECS_BY_INDEX.get(page.data_source.index_name)
+        if dimension_specs is None:
+            dimension_specs = DIMENSION_SPECS_BY_INDEX["scientific_production"]
+
+        for spec in dimension_specs:
             row_field_name = self._pick_row_field(field_settings, spec["row_field_candidates"])
+            if not row_field_name:
+                row_field_name = spec.get("row_field_fallback")
             if not row_field_name:
                 self.stdout.write(
                     self.style.WARNING(

--- a/search_gateway/fixtures/datasources.json
+++ b/search_gateway/fixtures/datasources.json
@@ -876,6 +876,24 @@
               "group_order": 50
             }
           },
+          "regions": {
+            "kind": "index",
+            "index_field_name": "regions",
+            "filter": {
+              "size": 100,
+              "order": {
+                "_key": "asc"
+              }
+            },
+            "settings": {
+              "label": "Region",
+              "support_query_operator": false,
+              "widget": "select",
+              "multiple_selection": true,
+              "group": "location",
+              "group_order": 50
+            }
+          },          
           "directory_type": {
             "kind": "index",
             "index_field_name": "directory_type",
@@ -982,6 +1000,10 @@
                   "label": "Practice"
                 },
                 {
+                  "value": "regions",
+                  "label": "Region"
+                },
+                {
                   "value": "states",
                   "label": "State"
                 },
@@ -1014,6 +1036,7 @@
               "classification",
               "practice",
               "institutions",
+              "regions",
               "states",
               "cities",
               "start_date_year"
@@ -1039,6 +1062,7 @@
               "classification",
               "practice",
               "institutions",
+              "regions",
               "states",
               "cities",
               "start_date_year"

--- a/search_gateway/migrations/_field_settings_snapshot.py
+++ b/search_gateway/migrations/_field_settings_snapshot.py
@@ -191,6 +191,7 @@ SOCIAL_BREAKDOWN_OPTIONS = [
     {"value": "action", "label": "Action"},
     {"value": "classification", "label": "Classification"},
     {"value": "practice", "label": "Practice"},
+    {"value": "regions", "label": "Region"},
     {"value": "states", "label": "State"},
     {"value": "cities", "label": "City"},
 ]
@@ -703,6 +704,13 @@ def _build_social_fields(legacy_fields):
                 **_group_settings("location", 40),
             }
         },
+        "regions": {
+            "settings": {
+                "label": "Region",
+                "widget": "select",
+                **_group_settings("location", 40),
+            }
+        },
         "directory_type": {
             "settings": {
                 "label": "Directory Type",
@@ -750,6 +758,7 @@ def _build_social_fields(legacy_fields):
             "classification",
             "practice",
             "institutions",
+            "regions",
             "states",
             "cities",
             "start_date_year",
@@ -774,6 +783,7 @@ def _build_social_fields(legacy_fields):
             "classification",
             "practice",
             "institutions",
+            "regions",
             "states",
             "cities",
             "start_date_year",


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige o cadastro e uso da dimensão **Regiões** na Observação de **Produção Social**.  
Ele garante que o campo `regions` esteja disponível de forma consistente no `DataSource` (`social_production`), nos formulários (`search` e `indicator`) e nas opções de `breakdown`, além de manter o seed de dimensões de observação preparado para criar/atualizar a tabela de regiões.

#### Onde a revisão poderia começar?
Começar por:
- `observation/management/commands/seed_observation_dimensions.py`
- `search_gateway/fixtures/datasources.json`
- `search_gateway/migrations/_field_settings_snapshot.py`

#### Como este poderia ser testado manualmente?
1. Sincronizar os DataSources:
   - `docker compose -f local.yml run --rm django python manage.py add_sources`
2. Reaplicar seed das dimensões de observação social:
   - `docker compose -f local.yml run --rm django python manage.py seed_observation_dimensions --index-name social_production`
3. Abrir a página de Observação de Produção Social e selecionar:
   - `Brazil - Social Production - Country - Documents - Regions`
4. Validar:
   - dimensão “Regions” aparece no seletor;
   - tabela renderiza colunas por ano;
   - linhas de regiões aparecem quando houver dados no índice.
5. (Opcional) Validar dados no OpenSearch:
   - agregação por `regions` em `social_production` para confirmar buckets.

#### Algum cenário de contexto que queira dar?
A dimensão de regiões era exibida no seletor, mas podia ficar vazia por inconsistência entre:
- configuração persistida do `DataSource` no banco (sem `regions`),
- fixtures/snapshot canônico,
- e seed da observação.

Este PR alinha esses pontos para evitar regressões e garantir comportamento consistente entre ambientes.

### Screenshots
- N/A (não informado)

#### Quais são tickets relevantes?
- N/A (não informado)

### Referências
- `observation/views.py` (resolução de `row_field_name`/`col_field_name` via `DataSource`)
- `search_gateway/models.py` (`DataSource.field_settings_dict`)
- `search_gateway/management/commands/add_sources.py` (sincronização fixture -> banco)
- `search_gateway/fixtures/datasources.json`
- `search_gateway/migrations/_field_settings_snapshot.py`