### PR TITLE
Adiciona a opção de download único.

### DIFF
--- a/observation/static/observation/css/table.css
+++ b/observation/static/observation/css/table.css
@@ -564,6 +564,30 @@
   margin-bottom: 4px;
 }
 
+.observation-export-progress-wrap {
+  display: block;
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.observation-export-meter {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: #e9edf5;
+  overflow: hidden;
+}
+
+.observation-export-meter-fill {
+  display: block;
+  height: 100%;
+  background: #2f67d8;
+  border-radius: inherit;
+  transition: width 160ms linear;
+}
+
 @media (max-width: 991px) {
   .observation-title {
     font-size: 32px;

--- a/observation/static/observation/js/table.js
+++ b/observation/static/observation/js/table.js
@@ -88,6 +88,329 @@
     return params;
   }
 
+  const EXPORT_STORAGE_KEY = "observation_export_jobs_v1";
+  let exportJobs = [];
+  let exportPollTimer = null;
+
+  function getExportStatusEndpoint(jobId) {
+    const config = window.searchPageConfig || {};
+    const startEndpoint = config.exportStartEndpoint || "";
+    return startEndpoint.replace(/\/start\/?$/, "/status/" + encodeURIComponent(jobId) + "/");
+  }
+
+  function getExportDownloadEndpoint(jobId) {
+    const config = window.searchPageConfig || {};
+    const startEndpoint = config.exportStartEndpoint || "";
+    return startEndpoint.replace(/\/start\/?$/, "/download/" + encodeURIComponent(jobId) + "/");
+  }
+
+  function loadJobsFromStorage() {
+    try {
+      const parsed = JSON.parse(window.localStorage.getItem(EXPORT_STORAGE_KEY) || "[]");
+      exportJobs = Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+      exportJobs = [];
+    }
+  }
+
+  function saveJobsToStorage() {
+    try {
+      window.localStorage.setItem(EXPORT_STORAGE_KEY, JSON.stringify(exportJobs.slice(0, 100)));
+    } catch (e) {}
+  }
+
+  function clearSavedJobs() {
+    exportJobs = [];
+    try {
+      window.localStorage.removeItem(EXPORT_STORAGE_KEY);
+    } catch (e) {}
+    if (exportPollTimer) {
+      clearInterval(exportPollTimer);
+      exportPollTimer = null;
+    }
+    renderExportJobs();
+  }
+
+  function upsertJob(job) {
+    const idx = exportJobs.findIndex(function (item) { return item.id === job.id; });
+    if (idx >= 0) exportJobs[idx] = Object.assign({}, exportJobs[idx], job);
+    else exportJobs.unshift(job);
+    saveJobsToStorage();
+  }
+
+  function isSingleFileModeEnabled() {
+    const toggle = document.getElementById("observation-export-single-file-toggle");
+    return Boolean(toggle && toggle.checked);
+  }
+
+  function updateExportControlsState() {
+    const rowLimit = document.getElementById("observation-export-row-limit");
+    const allBtn = document.getElementById("observation-export-all-btn");
+    const singleFileMode = isSingleFileModeEnabled();
+    if (rowLimit) rowLimit.disabled = singleFileMode;
+    if (allBtn) {
+      if (singleFileMode) {
+        allBtn.disabled = true;
+        allBtn.setAttribute("title", "Disabled while single-file mode is enabled.");
+      } else {
+        allBtn.removeAttribute("title");
+      }
+    }
+  }
+
+  function renderExportJobs() {
+    const container = document.getElementById("observation-export-jobs");
+    if (!container) return;
+    if (!exportJobs.length) {
+      container.innerHTML = '<div class="list-group-item text-muted small">No export jobs yet.</div>';
+      return;
+    }
+    let orderedJobs = exportJobs.slice().sort(function (a, b) {
+      const aIsBatch = a.job_type === "batch";
+      const bIsBatch = b.job_type === "batch";
+      if (aIsBatch !== bIsBatch) {
+        return aIsBatch ? -1 : 1;
+      }
+      const aIsRunningBatch = aIsBatch && (a.status === "running" || a.status === "queued");
+      const bIsRunningBatch = bIsBatch && (b.status === "running" || b.status === "queued");
+      if (aIsRunningBatch !== bIsRunningBatch) {
+        return aIsRunningBatch ? -1 : 1;
+      }
+      const aParent = String(a.parent_id || "");
+      const bParent = String(b.parent_id || "");
+      const aSeq = Number(a.sequence || 0);
+      const bSeq = Number(b.sequence || 0);
+      if (aParent && bParent && aParent === bParent && aSeq > 0 && bSeq > 0) {
+        return aSeq - bSeq;
+      }
+      return Number(b.created_at || 0) - Number(a.created_at || 0);
+    });
+    if (isSingleFileModeEnabled()) {
+      orderedJobs = orderedJobs.filter(function (job) { return job.job_type !== "batch"; });
+      if (orderedJobs.length > 1) orderedJobs = [orderedJobs[0]];
+    }
+    if (!orderedJobs.length) {
+      container.innerHTML = '<div class="list-group-item text-muted small">No export jobs yet.</div>';
+      return;
+    }
+    const html = orderedJobs.map(function (job) {
+      const done = job.status === "done";
+      const error = job.status === "error";
+      const isBatch = job.job_type === "batch";
+      const isRunning = job.status === "running" || job.status === "queued";
+      const statusClass = done ? "text-success" : (error ? "text-danger" : "text-muted");
+      const statusLabel = job.status || "queued";
+      const progress = Math.max(0, Math.min(100, Number(job.progress_percent || 0)));
+      const processed = Number(job.processed_rows || 0);
+      const total = Number(job.total_rows || 0);
+      const createdAt = Number(job.created_at || 0);
+      const isFresh = createdAt > 0 && (Date.now() / 1000 - createdAt) < (60 * 60);
+      const actionHtml = (done && !isBatch)
+        ? '<button type="button" class="btn btn-sm btn-outline-success observation-download-link' + (isFresh ? '' : ' disabled') + '" ' +
+          (isFresh ? ('data-job-id="' + job.id + '" data-file-name="' + (job.file_name || "observation.csv") + '"') : 'disabled') +
+          '>Download CSV</button>'
+        : '<button class="btn btn-sm btn-outline-secondary" type="button" disabled>' + (isBatch ? (job.ready_files_count || 0) + " files" : (progress + "%")) + "</button>";
+      const progressHtml = isRunning
+        ? '<div class="observation-export-progress-wrap">' +
+            '<div class="observation-export-meter" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' + progress + '">' +
+              '<div class="observation-export-meter-fill" style="width: ' + progress + '%;"></div>' +
+            "</div>" +
+          "</div>"
+        : "";
+      const sequenceLabel = Number(job.sequence || 0) > 0 ? ("#" + Number(job.sequence)) : "";
+      const rangeStart = Number(job.range_start || 0);
+      const rangeEnd = Number(job.range_end || 0);
+      const rangeLabel = (rangeStart > 0 && rangeEnd >= rangeStart) ? (" (" + rangeStart + "-" + rangeEnd + ")") : "";
+      return (
+        '<div class="list-group-item">' +
+          progressHtml +
+          '<div class="d-flex justify-content-between align-items-start gap-2">' +
+            '<div>' +
+              '<div class="small fw-semibold">' + (sequenceLabel ? (sequenceLabel + " - ") : "") + (job.dimension_label || job.dimension_slug || "Dimension") + rangeLabel + "</div>" +
+              '<div class="small ' + statusClass + '">Status: ' + statusLabel + " | " + (job.message || "") + "</div>" +
+              (job.debug ? ('<div class="small text-muted">' + String(job.debug) + "</div>") : "") +
+              '<div class="small text-muted">' + processed + "/" + total + " rows</div>" +
+            '</div>' +
+            actionHtml +
+          "</div>" +
+        "</div>"
+      );
+    }).join("");
+    container.innerHTML = html;
+  }
+
+  function downloadJobCsv(jobId, fileName) {
+    const endpoint = getExportDownloadEndpoint(jobId);
+    fetch(endpoint, { cache: "no-store" })
+      .then(function (response) {
+        const contentType = String(response.headers.get("content-type") || "").toLowerCase();
+        if (!response.ok || contentType.indexOf("text/csv") === -1) {
+          return response.text().then(function (text) {
+            throw new Error(text || "Could not download CSV.");
+          });
+        }
+        return response.blob().then(function (blob) {
+          if (!blob || blob.size === 0) {
+            throw new Error("Downloaded file is empty.");
+          }
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement("a");
+          link.href = url;
+          link.download = fileName || "observation.csv";
+          link.click();
+          setTimeout(function () { URL.revokeObjectURL(url); }, 1200);
+        });
+      })
+      .catch(function (err) {
+        window.alert(err.message || "Could not download CSV.");
+      });
+  }
+
+  function shouldPollJobs() {
+    return exportJobs.some(function (job) {
+      return job.status === "queued" || job.status === "running";
+    });
+  }
+
+  function pollExportJobs() {
+    if (!shouldPollJobs()) {
+      if (exportPollTimer) {
+        clearInterval(exportPollTimer);
+        exportPollTimer = null;
+      }
+      return;
+    }
+    const pending = exportJobs.filter(function (job) {
+      return job.status === "queued" || job.status === "running";
+    });
+    pending.forEach(function (job) {
+      fetch(getExportStatusEndpoint(job.id))
+        .then(function (r) { if (!r.ok) throw new Error("Status error"); return r.json(); })
+        .then(function (payload) {
+          if (payload && payload.job) {
+            upsertJob(payload.job);
+            const ready = (payload && payload.ready_jobs) || [];
+            ready.forEach(function (child) { upsertJob(child); });
+            renderExportJobs();
+          }
+        })
+        .catch(function () {});
+    });
+  }
+
+  function ensurePoller() {
+    if (exportPollTimer) return;
+    exportPollTimer = setInterval(pollExportJobs, 2000);
+  }
+
+  function startExport(scope, options) {
+    const config = window.searchPageConfig || {};
+    const endpoint = config.exportStartEndpoint || "";
+    if (!endpoint) return;
+    const opts = options || {};
+    const singleFileMode = Boolean(opts.singleFileMode);
+    const params = buildTableParams();
+    params.set("export_scope", singleFileMode ? "all" : (scope === "all" ? "all" : "current"));
+    params.set("batch_size", "1000");
+    params.set("progress_step", "100");
+    const rowLimit = document.getElementById("observation-export-row-limit");
+    if (!singleFileMode && rowLimit && rowLimit.value) params.set("row_bucket_size", rowLimit.value);
+    if (!singleFileMode && rowLimit && rowLimit.value) params.set("split_size", rowLimit.value);
+    params.set("split_mode", (opts.chunked && !singleFileMode) ? "chunked" : "single");
+    fetch(endpoint + "?" + params.toString())
+      .then(function (r) { if (!r.ok) throw new Error("Export start failed"); return r.json(); })
+      .then(function (payload) {
+        const jobs = (payload && payload.jobs) || [];
+        jobs.forEach(function (job) { upsertJob(job); });
+        renderExportJobs();
+        if (shouldPollJobs()) {
+          ensurePoller();
+          pollExportJobs();
+        }
+      })
+      .catch(function (err) {
+        window.alert(err.message || "Could not start export");
+      });
+  }
+
+  function initObservationExports() {
+    if (!document.getElementById("observation-export-jobs")) return;
+    loadJobsFromStorage();
+    renderExportJobs();
+    if (shouldPollJobs()) {
+      ensurePoller();
+      pollExportJobs();
+    }
+    const currentBtn = document.getElementById("observation-export-current-btn");
+    const allBtn = document.getElementById("observation-export-all-btn");
+    const clearBtn = document.getElementById("observation-export-clear-jobs-btn");
+    const singleFileToggle = document.getElementById("observation-export-single-file-toggle");
+    if (currentBtn) {
+      currentBtn.addEventListener("click", function () {
+        startExport("current", { chunked: false, singleFileMode: isSingleFileModeEnabled() });
+      });
+    }
+    if (allBtn) {
+      allBtn.addEventListener("click", function () { startExport("current", { chunked: true }); });
+    }
+    if (singleFileToggle) {
+      singleFileToggle.addEventListener("change", function () {
+        updateExportControlsState();
+        updateGenerateAllButtonState();
+        renderExportJobs();
+      });
+    }
+    if (clearBtn) {
+      clearBtn.addEventListener("click", function () {
+        if (!exportJobs.length) return;
+        if (window.confirm("Remove all saved download jobs from this browser?")) {
+          clearSavedJobs();
+        }
+      });
+    }
+    $("#observation-export-jobs")
+      .off("click.observationDownload")
+      .on("click.observationDownload", ".observation-download-link", function () {
+        if ($(this).prop("disabled")) return;
+        const jobId = $(this).data("job-id");
+        const fileName = $(this).data("file-name");
+        if (!jobId) return;
+        downloadJobCsv(String(jobId), String(fileName || "observation.csv"));
+      });
+    updateExportControlsState();
+    updateGenerateAllButtonState();
+  }
+
+  function getLoadedRowCount() {
+    const $table = $("#observation-table");
+    if (!$table.length) return 0;
+    if (typeof jQuery !== "undefined" && jQuery.fn.DataTable && $table.hasClass("dataTable")) {
+      try {
+        return $table.DataTable().rows().count();
+      } catch (e) {
+        return $("#observation-table tbody tr").length;
+      }
+    }
+    return $("#observation-table tbody tr").length;
+  }
+
+  function updateGenerateAllButtonState() {
+    const allBtn = document.getElementById("observation-export-all-btn");
+    if (!allBtn) return;
+    if (isSingleFileModeEnabled()) {
+      allBtn.disabled = true;
+      return;
+    }
+    const rowCount = getLoadedRowCount();
+    const shouldDisable = rowCount > 0 && rowCount < 1000;
+    allBtn.disabled = shouldDisable;
+    if (shouldDisable) {
+      allBtn.setAttribute("title", "Enable when there are at least 1000 items.");
+    } else {
+      allBtn.removeAttribute("title");
+    }
+  }
+
   function formatNumber(value) {
     return Number(value || 0).toLocaleString("en-US");
   }
@@ -163,6 +486,8 @@
       });
       $tbody.append("<tr>" + cells + "</tr>");
     });
+
+    updateGenerateAllButtonState();
 
     const numberColumns = [];
     for (let i = 2; i < 2 + columns.length; i++) numberColumns.push(i);
@@ -450,6 +775,7 @@
       injectCountryActions();
       updateHeaderSelectAllState();
       updateInfoText();
+      updateGenerateAllButtonState();
     });
     updateHeaderSelectAllState();
     updateInfoText();
@@ -1151,6 +1477,7 @@
         });
       }
       loadAndInitObservationTable();
+      initObservationExports();
     });
   }
 })();

--- a/observation/templates/observation/include/table.html
+++ b/observation/templates/observation/include/table.html
@@ -26,58 +26,137 @@
   <p class="text-muted small mb-2">{% trans "Use the detail icon next to country name. Use row checkboxes and then Compare selected." %}</p>
   <div class="observation-chart-meta">{% trans "Processing date" %}: 2026-03-17 | {% trans "Source" %}: OpenAlex</div>
 
-  <div id="observation-top-toolbar" class="observation-top-toolbar">
-    <div class="observation-actions">
-      <select id="actions-listbox" class="form-select observation-action-listbox" aria-label="Actions">
-        <option value="" selected>{% trans "Action" %}</option>
-        <option value="compare">{% trans "Compare selected" %}</option>
-        <option value="csv">{% trans "Download CSV (.csv)" %}</option>
-      </select>
-    </div>
-    <div class="observation-page-length-wrap">
-      <select id="observation-page-length" class="observation-page-length-select" aria-label="{% trans 'Rows per page' %}">
-        <option value="5">5</option>
-        <option value="10">10</option>
-        <option value="25">25</option>
-        <option value="50" selected>50</option>
-        <option value="100">100</option>
-        <option value="200">200</option>
-        <option value="300">300</option>
-        <option value="400">400</option>
-        <option value="500">500</option>
-      </select>
-    </div>
-  </div>
+  <ul class="nav nav-tabs mt-3" id="observation-content-tabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button
+        class="nav-link active"
+        id="observation-table-tab"
+        data-bs-toggle="tab"
+        data-bs-target="#observation-table-pane"
+        type="button"
+        role="tab"
+        aria-controls="observation-table-pane"
+        aria-selected="true"
+      >
+        {% trans "Table" %}
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button
+        class="nav-link"
+        id="observation-downloads-tab"
+        data-bs-toggle="tab"
+        data-bs-target="#observation-downloads-pane"
+        type="button"
+        role="tab"
+        aria-controls="observation-downloads-pane"
+        aria-selected="false"
+      >
+        {% trans "Downloads" %}
+      </button>
+    </li>
+  </ul>
 
-  <div class="observation-table-wrap">
-    <div id="observation-table-loading" class="text-center py-4 text-muted">
-      <i class="icon-spinner icon-spin"></i> {% trans "Loading table data..." %}
+  <div class="tab-content p-3" id="observation-content-tabs-body">
+    <div
+      class="tab-pane fade show active"
+      id="observation-table-pane"
+      role="tabpanel"
+      aria-labelledby="observation-table-tab"
+      tabindex="0"
+    >
+      <div id="observation-top-toolbar" class="observation-top-toolbar">
+        <div class="observation-actions">
+          <select id="actions-listbox" class="form-select observation-action-listbox" aria-label="Actions">
+            <option value="" selected>{% trans "Action" %}</option>
+            <option value="compare">{% trans "Compare selected" %}</option>
+            <option value="csv">{% trans "Download CSV (.csv)" %}</option>
+          </select>
+        </div>
+        <div class="observation-page-length-wrap">
+          <select id="observation-page-length" class="observation-page-length-select" aria-label="{% trans 'Rows per page' %}">
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="50" selected>50</option>
+            <option value="100">100</option>
+            <option value="200">200</option>
+            <option value="300">300</option>
+            <option value="400">400</option>
+            <option value="500">500</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="observation-table-wrap">
+        <div id="observation-table-loading" class="text-center py-4 text-muted">
+          <i class="icon-spinner icon-spin"></i> {% trans "Loading table data..." %}
+        </div>
+        <table id="observation-table" class="table table-striped table-bordered align-middle" style="display:none;">
+          <thead class="table-light">
+            <tr>
+              <th class="observation-select-col">
+                <label class="observation-select-header" for="select-all-checkbox" title="{% trans 'Select or deselect all rows' %}">
+                  <input id="select-all-checkbox" class="form-check-input observation-select-all-checkbox" type="checkbox" aria-label="{% trans 'Select or deselect all rows' %}">
+                  <span>{% trans "Select" %}</span>
+                </label>
+              </th>
+              <th id="observation-row-header">{{ observation_default_dimension.row_label }}</th>
+              <th class="observation-year-col" id="observation-col-header" data-placeholder="{{ observation_default_dimension.col_label }}"><!-- populated by JS --></th>
+            </tr>
+          </thead>
+          <tbody>
+            <!-- populated by JS from API -->
+          </tbody>
+          <tfoot>
+            <tr>
+              <th class="observation-select-col">-</th>
+              <th>{% trans "Totals" %}</th>
+              <th class="observation-total-col"><!-- populated by JS --></th>
+            </tr>
+          </tfoot>
+        </table>
+        <div id="observation-table-error" class="alert alert-danger mt-2" style="display:none;" role="alert"></div>
+      </div>
     </div>
-    <table id="observation-table" class="table table-striped table-bordered align-middle" style="display:none;">
-      <thead class="table-light">
-        <tr>
-          <th class="observation-select-col">
-            <label class="observation-select-header" for="select-all-checkbox" title="{% trans 'Select or deselect all rows' %}">
-              <input id="select-all-checkbox" class="form-check-input observation-select-all-checkbox" type="checkbox" aria-label="{% trans 'Select or deselect all rows' %}">
-              <span>{% trans "Select" %}</span>
-            </label>
-          </th>
-          <th id="observation-row-header">{{ observation_default_dimension.row_label }}</th>
-          <th class="observation-year-col" id="observation-col-header" data-placeholder="{{ observation_default_dimension.col_label }}"><!-- populated by JS --></th>
-        </tr>
-      </thead>
-      <tbody>
-        <!-- populated by JS from API -->
-      </tbody>
-      <tfoot>
-        <tr>
-          <th class="observation-select-col">-</th>
-          <th>{% trans "Totals" %}</th>
-          <th class="observation-total-col"><!-- populated by JS --></th>
-        </tr>
-      </tfoot>
-    </table>
-    <div id="observation-table-error" class="alert alert-danger mt-2" style="display:none;" role="alert"></div>
+
+    <div
+      class="tab-pane fade"
+      id="observation-downloads-pane"
+      role="tabpanel"
+      aria-labelledby="observation-downloads-tab"
+      tabindex="0"
+    >
+      <div class="observation-downloads">
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-2">
+          <div class="d-flex gap-2 align-items-center flex-wrap">
+            <label class="small text-muted mb-0" for="observation-export-row-limit">{% trans "Rows limit" %}</label>
+            <select id="observation-export-row-limit" class="form-select form-select-sm" style="min-width: 110px;">
+              <option value="1000" selected>1000</option>
+              <option value="2000">2000</option>
+              <option value="3000">3000</option>
+              <option value="4000">4000</option>
+              <option value="5000">5000</option>
+            </select>
+            <button id="observation-export-current-btn" class="btn btn-sm btn-outline-primary" type="button">
+              {% trans "Generate" %}
+            </button>
+            <button id="observation-export-all-btn" class="btn btn-sm btn-primary" type="button">
+              {% trans "Generate all CSVs" %}
+            </button>
+            <button id="observation-export-clear-jobs-btn" class="btn btn-sm btn-outline-danger" type="button">
+              {% trans "Clear .csv" %}
+            </button>
+            <div class="form-check form-check-inline mb-0">
+              <input class="form-check-input" type="checkbox" id="observation-export-single-file-toggle">
+              <label class="form-check-label small text-muted" for="observation-export-single-file-toggle">{% trans "Single file (.csv)" %}</label>
+            </div>
+          </div>
+        </div>
+        <p class="small text-muted mb-2">{% trans "Jobs are persisted in your browser and can be resumed after reload." %}</p>
+        <div id="observation-export-jobs" class="list-group"></div>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/observation/templates/observation/observation_page.html
+++ b/observation/templates/observation/observation_page.html
@@ -23,6 +23,7 @@
 {{ filter_metadata|json_script:"filter-metadata-data" }}
 {{ observation_dimensions|json_script:"observation-dimensions-data" }}
 {{ observation_default_dimension|json_script:"observation-default-dimension-data" }}
+{{ searchable_fields|json_script:"searchable-fields-data" }}
 <script src="{% static 'observation/js/search_page.js' %}"></script>
 <script src="{% static 'observation/js/table.js' %}"></script>
 <link href="{% static 'search/css/custom.css' %}" rel="stylesheet">
@@ -34,16 +35,15 @@
         apiEndpoint: '{% url "observation:list" %}',
         filtersApiEndpoint: '{% url "observation:filters" %}',
         tableApiEndpoint: '{% url "observation:table" %}',
+        exportStartEndpoint: '{% url "observation:export_start" %}',
         filters: JSON.parse(document.getElementById('filters-data').textContent),
         filterMetadata: JSON.parse(document.getElementById('filter-metadata-data').textContent),
         observationPageId: '{{ observation_page_id|default_if_none:""|escapejs }}',
         dimensions: JSON.parse(document.getElementById('observation-dimensions-data').textContent),
         defaultDimension: JSON.parse(document.getElementById('observation-default-dimension-data').textContent),
-        searchableFields: [
-            {% for value, label in searchable_fields %}
-            { value: '{{ value|escapejs }}', label: '{{ label|escapejs }}' }{% if not forloop.last %},{% endif %}
-            {% endfor %}
-        ],
+        searchableFields: JSON.parse(document.getElementById('searchable-fields-data').textContent).map(function (item) {
+            return { value: item[0], label: item[1] };
+        }),
     };
 </script>
 {% endblock %}

--- a/observation/urls.py
+++ b/observation/urls.py
@@ -20,4 +20,19 @@ urlpatterns = [
         views.table,
         name="table",
     ),
+    path(
+        "export/start/",
+        views.export_start,
+        name="export_start",
+    ),
+    path(
+        "export/status/<str:job_id>/",
+        views.export_status,
+        name="export_status",
+    ),
+    path(
+        "export/download/<str:job_id>/",
+        views.export_download,
+        name="export_download",
+    ),
 ]

--- a/observation/views.py
+++ b/observation/views.py
@@ -4,13 +4,23 @@ No changes to the search application.
 """
 import json
 import logging
+import traceback
+import time
+import uuid
+import builtins
+import threading
+from copy import deepcopy
+from io import StringIO
+import csv
 
 from django.conf import settings
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET
 
 from observation.models import ObservationPage
+from search_gateway.filter_mapping import get_mapped_filters
+from search_gateway.query import build_bool_query_from_search_params
 from search_gateway.request_filters import (
     extract_applied_filters,
     normalize_option_filters,
@@ -20,6 +30,8 @@ from search_gateway.service import SearchGatewayService
 logger = logging.getLogger(__name__)
 
 OBSERVATION_SEARCH_FORM_KEY = "search"
+EXPORT_JOBS = {}
+EXPORT_JOBS_LOCK = threading.Lock()
 
 
 def _get_index_name(request):
@@ -42,6 +54,29 @@ def _build_nested_terms_aggs(*, row_field, col_field, row_size, col_size):
     }
 
 
+def _expand_agg_field_candidates(candidates):
+    expanded = []
+    for candidate in candidates:
+        cleaned = str(candidate or "").strip()
+        if not cleaned:
+            continue
+        variants = [cleaned]
+        if not cleaned.endswith(".keyword"):
+            variants.append(f"{cleaned}.keyword")
+        for variant in variants:
+            if variant not in expanded:
+                expanded.append(variant)
+    return expanded
+
+
+def _is_text_fielddata_error(exc):
+    message = str(exc or "")
+    return (
+        "Text fields are not optimised" in message
+        and "fielddata=true" in message
+    )
+
+
 def _resolve_observation_dimension(request):
     page_id = request.GET.get("page_id")
     dimension_slug = request.GET.get("dimension_slug")
@@ -58,8 +93,8 @@ def _resolve_observation_dimension(request):
     return page.get_default_dimension_config()
 
 
-def _parse_query_clauses(request):
-    raw = request.GET.get("search_clauses")
+def _parse_query_clauses_from_source(source):
+    raw = source.get("search_clauses")
     if not raw:
         return []
     try:
@@ -120,13 +155,909 @@ def _apply_lookup_labels_to_rows(service, row_field_name, result):
 
     return result
 
+
+def _build_dimension_table_result(query_source, service, dimension):
+    applied_filters = extract_applied_filters(
+        query_source,
+        service.data_source,
+        form_key=OBSERVATION_SEARCH_FORM_KEY,
+    )
+    selected_filters = normalize_option_filters(applied_filters)
+    text_search = query_source.get("search", "")
+    query_clauses = _parse_query_clauses_from_source(query_source)
+    field_settings = service.data_source.field_settings_dict or {}
+
+    row_field_name = dimension.get("row_field_name") or "country"
+    col_field_name = dimension.get("col_field_name") or "publication_year"
+    row_cfg = field_settings.get(row_field_name, {})
+    col_cfg = field_settings.get(col_field_name, {})
+    row_field = row_cfg.get("index_field_name")
+    col_field = col_cfg.get("index_field_name")
+
+    row_size = int(
+        dimension.get("row_bucket_size")
+        or row_cfg.get("filter", {}).get("size", 500)
+    )
+    col_size = int(
+        dimension.get("col_bucket_size")
+        or col_cfg.get("filter", {}).get("size", 300)
+    )
+    parse_config = {
+        "row_agg_name": "by_row",
+        "col_agg_name": "by_col",
+        "row_field_name": row_field_name,
+    }
+    row_transform = row_cfg.get("settings", {}).get("display_transform")
+    if row_transform:
+        parse_config["row_display_transform"] = row_transform
+    def _run_aggregation(row_index_field, col_index_field):
+        if not row_index_field or not col_index_field:
+            return {"columns": [], "rows": [], "grand_total": 0}
+        aggs = _build_nested_terms_aggs(
+            row_field=row_index_field,
+            col_field=col_index_field,
+            row_size=row_size,
+            col_size=col_size,
+        )
+        return service.search_aggregation(
+            aggs=aggs,
+            query_text=text_search if not query_clauses else None,
+            query_clauses=query_clauses if query_clauses else None,
+            filters=selected_filters,
+            parse_config=parse_config,
+        )
+
+    row_candidates = _expand_agg_field_candidates(
+        [row_field, row_field_name, "author_country_codes", "country"]
+    )
+    col_candidates = _expand_agg_field_candidates(
+        [col_field, col_field_name, "publication_year"]
+    )
+
+    result = {"columns": [], "rows": [], "grand_total": 0}
+    used_pair = None
+    for row_candidate in row_candidates:
+        for col_candidate in col_candidates:
+            try:
+                candidate_result = _run_aggregation(row_candidate, col_candidate)
+            except Exception as exc:
+                if _is_text_fielddata_error(exc):
+                    logger.info(
+                        "Skipping aggregation candidate pair row=%s col=%s due to text fielddata restriction",
+                        row_candidate,
+                        col_candidate,
+                    )
+                    continue
+                raise
+            if (candidate_result.get("rows") or []):
+                result = candidate_result
+                used_pair = (row_candidate, col_candidate)
+                break
+            if not result.get("rows"):
+                result = candidate_result
+        if used_pair:
+            break
+    if used_pair and (used_pair[0] != row_field or used_pair[1] != col_field):
+        logger.info(
+            "Observation export/table fallback fields in use: row=%s col=%s (configured row=%s col=%s)",
+            used_pair[0],
+            used_pair[1],
+            row_field,
+            col_field,
+        )
+    return _apply_lookup_labels_to_rows(service, row_field_name, result)
+
+
+def _build_dimension_table_result_all_rows(
+    query_source,
+    service,
+    dimension,
+    split_size=1000,
+    progress_callback=None,
+):
+    """
+    Build the same row/column structure used by the table, but paginating all row buckets
+    with composite aggregation so exports are not capped by terms size.
+    """
+    applied_filters = extract_applied_filters(
+        query_source,
+        service.data_source,
+        form_key=OBSERVATION_SEARCH_FORM_KEY,
+    )
+    selected_filters = normalize_option_filters(applied_filters)
+    text_search = query_source.get("search", "")
+    query_clauses = _parse_query_clauses_from_source(query_source)
+    field_settings = service.data_source.field_settings_dict or {}
+
+    row_field_name = dimension.get("row_field_name") or "country"
+    col_field_name = dimension.get("col_field_name") or "publication_year"
+    row_cfg = field_settings.get(row_field_name, {})
+    col_cfg = field_settings.get(col_field_name, {})
+    configured_row_field = row_cfg.get("index_field_name")
+    configured_col_field = col_cfg.get("index_field_name")
+    col_size = int(
+        dimension.get("col_bucket_size")
+        or col_cfg.get("filter", {}).get("size", 300)
+    )
+
+    mapped_filters = get_mapped_filters(selected_filters or {}, service.field_settings)
+    bool_query = build_bool_query_from_search_params(
+        query_text=text_search if not query_clauses else None,
+        query_clauses=query_clauses if query_clauses else None,
+        filters=mapped_filters,
+    )
+
+    row_transform = row_cfg.get("settings", {}).get("display_transform")
+
+    def _col_sort_key(key):
+        try:
+            return (0, int(key))
+        except (TypeError, ValueError):
+            return (1, str(key))
+
+    row_candidates = _expand_agg_field_candidates(
+        [configured_row_field, row_field_name, "author_country_codes", "country"]
+    )
+    col_candidates = _expand_agg_field_candidates(
+        [configured_col_field, col_field_name, "publication_year"]
+    )
+
+    page_size = max(100, int(split_size or 1000))
+    best_result = {"columns": [], "rows": [], "grand_total": 0}
+    used_pair = None
+    processed_rows = 0
+
+    for row_field in row_candidates:
+        for col_field in col_candidates:
+            after_key = None
+            rows = []
+            col_keys = set()
+            grand_total = 0
+            try:
+                while True:
+                    composite = {
+                        "size": page_size,
+                        "sources": [{"row_key": {"terms": {"field": row_field}}}],
+                    }
+                    if after_key:
+                        composite["after"] = after_key
+                    aggs = {
+                        "by_row": {
+                            "composite": composite,
+                            "aggs": {
+                                "by_col": {"terms": {"field": col_field, "size": col_size}},
+                            },
+                        }
+                    }
+                    body = {
+                        "size": 0,
+                        "track_total_hits": True,
+                        "query": {"bool": bool_query},
+                        "aggs": aggs,
+                    }
+                    response = service.client.search(
+                        index=service.index_name,
+                        body=body,
+                        request_cache=True,
+                        request_timeout=service.request_timeout,
+                    )
+                    row_agg = (response.get("aggregations") or {}).get("by_row") or {}
+                    buckets = row_agg.get("buckets") or []
+                    if not buckets:
+                        break
+                    for rb in buckets:
+                        raw_key = ((rb.get("key") or {}).get("row_key"))
+                        if row_transform:
+                            label = raw_key
+                        else:
+                            label = raw_key
+                        values = {}
+                        for cb in (rb.get("by_col") or {}).get("buckets", []) or []:
+                            ck = cb.get("key")
+                            if ck is None:
+                                continue
+                            values[str(ck)] = cb.get("doc_count", 0)
+                            col_keys.add(ck)
+                        rows.append({"key": raw_key, "label": label, "values": values})
+                        grand_total += int(rb.get("doc_count") or 0)
+                        processed_rows += 1
+                    if callable(progress_callback):
+                        progress_callback(processed_rows)
+                    after_key = row_agg.get("after_key")
+                    if not after_key:
+                        break
+            except Exception as exc:
+                if _is_text_fielddata_error(exc):
+                    logger.info(
+                        "Skipping composite aggregation candidate pair row=%s col=%s due to text fielddata restriction",
+                        row_field,
+                        col_field,
+                    )
+                    continue
+                raise
+
+            columns = [str(c) for c in sorted(col_keys, key=_col_sort_key)]
+            candidate_result = {"columns": columns, "rows": rows, "grand_total": grand_total}
+            if rows:
+                used_pair = (row_field, col_field)
+                best_result = candidate_result
+                break
+            if not best_result.get("rows"):
+                best_result = candidate_result
+        if used_pair:
+            break
+
+    if used_pair and (used_pair[0] != configured_row_field or used_pair[1] != configured_col_field):
+        logger.info(
+            "Observation export(all rows) fallback fields in use: row=%s col=%s (configured row=%s col=%s)",
+            used_pair[0],
+            used_pair[1],
+            configured_row_field,
+            configured_col_field,
+        )
+    return _apply_lookup_labels_to_rows(service, row_field_name, best_result)
+
+
+def _job_snapshot(job):
+    snapshot = {
+        "id": job["id"],
+        "job_type": job.get("job_type", "file"),
+        "parent_id": job.get("parent_id"),
+        "sequence": job.get("sequence"),
+        "range_start": job.get("range_start"),
+        "range_end": job.get("range_end"),
+        "status": job["status"],
+        "message": job.get("message", ""),
+        "progress_percent": job.get("progress_percent", 0),
+        "processed_rows": job.get("processed_rows", 0),
+        "total_rows": job.get("total_rows", 0),
+        "file_name": job.get("file_name", ""),
+        "dimension_slug": job.get("dimension_slug", ""),
+        "dimension_label": job.get("dimension_label", ""),
+        "created_at": job.get("created_at"),
+        "finished_at": job.get("finished_at"),
+    }
+    if job.get("status") == "error" and job.get("debug"):
+        snapshot["debug"] = job.get("debug")
+    if job.get("job_type") == "batch":
+        snapshot["ready_files_count"] = len(job.get("ready_file_ids") or [])
+    return snapshot
+
+
+def _run_export_job(
+    job_id,
+    *,
+    query_string,
+    index_name,
+    dimension,
+    batch_size,
+    progress_step,
+    export_scope="current",
+    split_size=1000,
+):
+    stage = "initializing"
+    job = EXPORT_JOBS.get(job_id)
+    if not job:
+        return
+    job["status"] = "running"
+    job["message"] = _("Preparing CSV data...")
+    EXPORT_JOBS[job_id] = job
+
+    try:
+        from django.http import QueryDict
+
+        stage = "parse_querystring"
+        request_get = QueryDict(query_string, mutable=False)
+        stage = "build_service"
+        service = SearchGatewayService(index_name=index_name)
+        if not service.data_source:
+            raise ValueError("Invalid data source for export")
+
+        stage = "build_table_result"
+        scope_is_all = str(export_scope or "current").strip().lower() == "all"
+        discovery_pages = {"count": 0}
+
+        def _update_discovery_progress(discovered_rows):
+            if not scope_is_all:
+                return
+            if discovered_rows <= 0:
+                return
+            discovery_pages["count"] += 1
+            # Keep discovery phase under 70%, then writing phase fills to 100%.
+            discovery_progress = min(70, 5 + (discovery_pages["count"] * 2))
+            current = EXPORT_JOBS.get(job_id)
+            if not current:
+                return
+            current["processed_rows"] = int(discovered_rows)
+            current["total_rows"] = max(int(discovered_rows), int(current.get("total_rows") or 0))
+            current["progress_percent"] = max(int(current.get("progress_percent") or 0), discovery_progress)
+            current["message"] = _("Collecting rows for single CSV... %(rows)s") % {
+                "rows": discovered_rows,
+            }
+            EXPORT_JOBS[job_id] = current
+
+        if str(export_scope or "current").strip().lower() == "all":
+            result = _build_dimension_table_result_all_rows(
+                request_get,
+                service,
+                dimension,
+                split_size=split_size,
+                progress_callback=_update_discovery_progress,
+            )
+        else:
+            result = _build_dimension_table_result(request_get, service, dimension)
+        stage = "extract_rows"
+        columns = tuple(result.get("columns") or [])
+        rows = tuple(result.get("rows") or [])
+        total_rows = len(rows)
+
+        job = EXPORT_JOBS[job_id]
+        job["total_rows"] = total_rows
+        job["processed_rows"] = 0
+        job["progress_percent"] = 0
+        job["message"] = _("Formatting CSV...")
+        EXPORT_JOBS[job_id] = job
+
+        stage = "prepare_csv"
+        output = StringIO()
+        writer = csv.writer(output)
+        row_label = dimension.get("row_label") or _("Row")
+        if columns:
+            writer.writerow([row_label] + builtins.list(columns))
+        else:
+            writer.writerow([row_label, _("Message")])
+            if total_rows == 0:
+                writer.writerow(["-", _("No data returned for selected dimension and filters")])
+
+        stage = "write_csv_rows"
+        processed = 0
+        step = max(1, int(progress_step or 100))
+        chunk_size = max(1, int(batch_size or 1000))
+        for chunk_start in range(0, total_rows, chunk_size):
+            chunk = rows[chunk_start:chunk_start + chunk_size]
+            for row in chunk:
+                values = row.get("values") or {}
+                writer.writerow(
+                    [row.get("label") or row.get("key") or ""]
+                    + [values.get(col, 0) for col in columns]
+                )
+                processed += 1
+                if processed % step == 0 or processed == total_rows:
+                    current = EXPORT_JOBS[job_id]
+                    current["processed_rows"] = processed
+                    if scope_is_all:
+                        current["progress_percent"] = 70 + int((processed * 30) / max(total_rows, 1))
+                    else:
+                        current["progress_percent"] = int((processed * 100) / max(total_rows, 1))
+                    current["message"] = _("Generating CSV... %(processed)s/%(total)s") % {
+                        "processed": processed,
+                        "total": total_rows,
+                    }
+                    EXPORT_JOBS[job_id] = current
+            time.sleep(0.01)
+
+        stage = "finalize_job"
+        done = EXPORT_JOBS[job_id]
+        done["status"] = "done"
+        done["csv_content"] = output.getvalue()
+        done["processed_rows"] = total_rows
+        done["progress_percent"] = 100
+        done["message"] = _("CSV ready (%(rows)s rows)") % {"rows": total_rows}
+        done["finished_at"] = int(time.time())
+        EXPORT_JOBS[job_id] = done
+    except Exception as exc:
+        logger.exception("Observation export failed: %s", exc)
+        failed = EXPORT_JOBS.get(job_id)
+        if not failed:
+            return
+        failed["status"] = "error"
+        failed["message"] = f"{type(exc).__name__} at {stage}: {exc}"
+        failed["debug"] = traceback.format_exc(limit=6)
+        failed["finished_at"] = int(time.time())
+        EXPORT_JOBS[job_id] = failed
+
+
+def _store_done_csv_job(
+    *,
+    dimension,
+    file_name,
+    csv_content,
+    total_rows,
+    parent_id=None,
+    sequence=None,
+    range_start=None,
+    range_end=None,
+):
+    job_id = str(uuid.uuid4())
+    slug = dimension.get("slug") or ""
+    label = dimension.get("menu_label") or slug or _("Dimension")
+    safe_csv_content = csv_content
+    if not isinstance(safe_csv_content, str) or not safe_csv_content.strip():
+        fallback = StringIO()
+        fallback_writer = csv.writer(fallback)
+        fallback_writer.writerow([_("Message")])
+        fallback_writer.writerow([_("No data available for export")])
+        safe_csv_content = fallback.getvalue()
+    with EXPORT_JOBS_LOCK:
+        EXPORT_JOBS[job_id] = {
+        "id": job_id,
+        "job_type": "file",
+        "parent_id": parent_id,
+        "sequence": sequence,
+        "range_start": range_start,
+        "range_end": range_end,
+        "status": "done",
+        "message": _("CSV ready (%(rows)s rows)") % {"rows": total_rows},
+        "progress_percent": 100,
+        "processed_rows": total_rows,
+        "total_rows": total_rows,
+        "file_name": file_name,
+        "dimension_slug": slug,
+        "dimension_label": label,
+        "created_at": int(time.time()),
+        "finished_at": int(time.time()),
+        "csv_content": safe_csv_content,
+        }
+        return _job_snapshot(EXPORT_JOBS[job_id])
+
+
+def _store_pending_csv_job(*, dimension, file_name, message):
+    job_id = str(uuid.uuid4())
+    slug = dimension.get("slug") or ""
+    label = dimension.get("menu_label") or slug or _("Dimension")
+    with EXPORT_JOBS_LOCK:
+        EXPORT_JOBS[job_id] = {
+            "id": job_id,
+            "job_type": "file",
+            "status": "queued",
+            "message": message,
+            "progress_percent": 0,
+            "processed_rows": 0,
+            "total_rows": 0,
+            "file_name": file_name,
+            "dimension_slug": slug,
+            "dimension_label": label,
+            "created_at": int(time.time()),
+            "finished_at": None,
+            "csv_content": "",
+        }
+        return _job_snapshot(EXPORT_JOBS[job_id])
+
+
+def _store_error_job(*, dimension, message, debug=""):
+    job_id = str(uuid.uuid4())
+    slug = dimension.get("slug") or ""
+    label = dimension.get("menu_label") or slug or _("Dimension")
+    with EXPORT_JOBS_LOCK:
+        EXPORT_JOBS[job_id] = {
+        "id": job_id,
+        "job_type": "file",
+        "status": "error",
+        "message": message,
+        "progress_percent": 0,
+        "processed_rows": 0,
+        "total_rows": 0,
+        "file_name": "",
+        "dimension_slug": slug,
+        "dimension_label": label,
+        "created_at": int(time.time()),
+        "finished_at": int(time.time()),
+        "csv_content": "",
+        "debug": debug or "",
+        }
+        return _job_snapshot(EXPORT_JOBS[job_id])
+
+
+def _store_batch_job(*, dimension, message):
+    job_id = str(uuid.uuid4())
+    slug = dimension.get("slug") or ""
+    label = dimension.get("menu_label") or slug or _("Dimension")
+    with EXPORT_JOBS_LOCK:
+        EXPORT_JOBS[job_id] = {
+            "id": job_id,
+            "job_type": "batch",
+            "status": "running",
+            "message": message,
+            "progress_percent": 0,
+            "processed_rows": 0,
+            "total_rows": 0,
+            "file_name": "",
+            "dimension_slug": slug,
+            "dimension_label": label,
+            "created_at": int(time.time()),
+            "finished_at": None,
+            "csv_content": "",
+            "ready_file_ids": [],
+        }
+        return _job_snapshot(EXPORT_JOBS[job_id])
+
+
+def _build_csv_content(*, dimension, columns, rows):
+    output = StringIO()
+    writer = csv.writer(output)
+    row_label = dimension.get("row_label") or _("Row")
+    if columns:
+        writer.writerow([row_label] + builtins.list(columns))
+        for row in rows:
+            values = row.get("values") or {}
+            writer.writerow(
+                [row.get("label") or row.get("key") or ""]
+                + [values.get(col, 0) for col in columns]
+            )
+    elif rows:
+        writer.writerow([row_label, _("Total")])
+        for row in rows:
+            values = row.get("values") or {}
+            total = 0
+            for value in values.values():
+                try:
+                    total += int(value or 0)
+                except (TypeError, ValueError):
+                    continue
+            writer.writerow([row.get("label") or row.get("key") or "", total])
+    else:
+        writer.writerow([row_label, _("Message")])
+        writer.writerow(["-", _("No data returned for selected dimension and filters")])
+    return output.getvalue()
+
+
+def _normalize_csv_value(value):
+    if value is None:
+        return ""
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _build_documents_csv_content(rows):
+    output = StringIO()
+    writer = csv.writer(output)
+    if not rows:
+        writer.writerow([_("Message")])
+        writer.writerow([_("No documents returned for selected dimension and filters")])
+        return output.getvalue()
+
+    header_keys = []
+    seen = set()
+    for source in rows:
+        for key in source.keys():
+            if key not in seen:
+                seen.add(key)
+                header_keys.append(str(key))
+
+    writer.writerow(header_keys)
+    for source in rows:
+        writer.writerow([_normalize_csv_value(source.get(key)) for key in header_keys])
+    return output.getvalue()
+
+
+def _build_document_export_jobs(*, dimension, query_source, index_name, split_size):
+    service = SearchGatewayService(index_name=index_name)
+    data_source = service.data_source
+    if not data_source:
+        return []
+
+    query_clauses = _parse_query_clauses_from_source(query_source)
+    text_search = query_source.get("search", "")
+    applied_filters = extract_applied_filters(
+        query_source,
+        data_source,
+        form_key=OBSERVATION_SEARCH_FORM_KEY,
+    )
+    selected_filters = normalize_option_filters(applied_filters)
+
+    jobs = []
+    file_slug = (dimension.get("slug") or "dimension").strip() or "dimension"
+    mapped_filters = get_mapped_filters(selected_filters or {}, service.field_settings)
+    bool_query = build_bool_query_from_search_params(
+        query_text=text_search if not query_clauses else None,
+        query_clauses=query_clauses if query_clauses else None,
+        filters=mapped_filters,
+    )
+    search_body = {
+        "size": split_size,
+        "query": {"bool": bool_query},
+        "sort": ["_doc"],
+    }
+    if service.source_fields:
+        search_body["_source"] = service.source_fields
+
+    scroll_id = None
+    part_idx = 1
+    try:
+        response = service.client.search(
+            index=service.index_name,
+            body=search_body,
+            scroll="2m",
+            request_timeout=service.request_timeout,
+        )
+        scroll_id = response.get("_scroll_id")
+        while True:
+            hits = ((response.get("hits") or {}).get("hits") or [])
+            if not hits:
+                break
+            sources = [hit.get("_source") or {} for hit in hits]
+            csv_content = _build_documents_csv_content(sources)
+            file_name = f"observation_{file_slug}_{int(time.time())}_part_{part_idx:03d}.csv"
+            jobs.append(
+                _store_done_csv_job(
+                    dimension=dimension,
+                    file_name=file_name,
+                    csv_content=csv_content,
+                    total_rows=len(sources),
+                    sequence=part_idx,
+                    range_start=((part_idx - 1) * split_size) + 1,
+                    range_end=((part_idx - 1) * split_size) + len(sources),
+                )
+            )
+            part_idx += 1
+            if not scroll_id:
+                break
+            response = service.client.scroll(
+                scroll_id=scroll_id,
+                scroll="2m",
+                request_timeout=service.request_timeout,
+            )
+            scroll_id = response.get("_scroll_id") or scroll_id
+    finally:
+        if scroll_id:
+            try:
+                service.client.clear_scroll(scroll_id=scroll_id)
+            except Exception:
+                logger.warning("Failed to clear OpenSearch scroll context", exc_info=True)
+    return jobs
+
+
+def _run_chunked_export_async(*, batch_job_id, dimension, query_source, index_name, split_size):
+    try:
+        service = SearchGatewayService(index_name=index_name)
+        data_source = service.data_source
+        if not data_source:
+            raise ValueError("Invalid data source for export")
+
+        applied_filters = extract_applied_filters(
+            query_source,
+            data_source,
+            form_key=OBSERVATION_SEARCH_FORM_KEY,
+        )
+        selected_filters = normalize_option_filters(applied_filters)
+        query_clauses = _parse_query_clauses_from_source(query_source)
+        text_search = query_source.get("search", "")
+        mapped_filters = get_mapped_filters(selected_filters or {}, service.field_settings)
+        bool_query = build_bool_query_from_search_params(
+            query_text=text_search if not query_clauses else None,
+            query_clauses=query_clauses if query_clauses else None,
+            filters=mapped_filters,
+        )
+
+        field_settings = data_source.field_settings_dict or {}
+        row_field_name = dimension.get("row_field_name") or "country"
+        col_field_name = dimension.get("col_field_name") or "publication_year"
+        row_cfg = field_settings.get(row_field_name, {})
+        col_cfg = field_settings.get(col_field_name, {})
+        configured_row_field = row_cfg.get("index_field_name")
+        configured_col_field = col_cfg.get("index_field_name")
+        col_size = int(
+            dimension.get("col_bucket_size")
+            or col_cfg.get("filter", {}).get("size", 300)
+        )
+
+        row_candidates = []
+        for candidate in [configured_row_field, row_field_name, "author_country_codes", "country"]:
+            cleaned = str(candidate or "").strip()
+            if cleaned and cleaned not in row_candidates:
+                row_candidates.append(cleaned)
+        col_candidates = []
+        for candidate in [configured_col_field, col_field_name, "publication_year"]:
+            cleaned = str(candidate or "").strip()
+            if cleaned and cleaned not in col_candidates:
+                col_candidates.append(cleaned)
+
+        def _col_sort_key(key):
+            try:
+                return (0, int(key))
+            except (TypeError, ValueError):
+                return (1, str(key))
+
+        def _get_column_keys(col_field):
+            body = {
+                "size": 0,
+                "query": {"bool": bool_query},
+                "aggs": {
+                    "cols": {
+                        "terms": {"field": col_field, "size": col_size}
+                    }
+                },
+            }
+            response = service.client.search(
+                index=service.index_name,
+                body=body,
+                request_cache=True,
+                request_timeout=service.request_timeout,
+            )
+            buckets = ((response.get("aggregations") or {}).get("cols") or {}).get("buckets") or []
+            return [str(bucket.get("key")) for bucket in buckets if bucket.get("key") is not None]
+
+        def _estimate_total_rows(row_field):
+            body = {
+                "size": 0,
+                "query": {"bool": bool_query},
+                "aggs": {"row_count": {"cardinality": {"field": row_field}}},
+            }
+            response = service.client.search(
+                index=service.index_name,
+                body=body,
+                request_cache=True,
+                request_timeout=service.request_timeout,
+            )
+            return int((((response.get("aggregations") or {}).get("row_count") or {}).get("value")) or 0)
+
+        split_size = max(1, int(split_size or 1000))
+        page_size = max(100, min(split_size, 1000))
+        processed_rows = 0
+        part_idx = 1
+        file_slug = (dimension.get("slug") or "dimension").strip() or "dimension"
+        used_pair = None
+        buffer_rows = []
+        columns = []
+        estimated_total = 0
+
+        for row_field in row_candidates:
+            for col_field in col_candidates:
+                columns = sorted(_get_column_keys(col_field), key=_col_sort_key)
+                estimated_total = _estimate_total_rows(row_field)
+                after_key = None
+                found_any = False
+                while True:
+                    composite = {
+                        "size": page_size,
+                        "sources": [{"row_key": {"terms": {"field": row_field}}}],
+                    }
+                    if after_key:
+                        composite["after"] = after_key
+                    body = {
+                        "size": 0,
+                        "query": {"bool": bool_query},
+                        "aggs": {
+                            "by_row": {
+                                "composite": composite,
+                                "aggs": {
+                                    "by_col": {"terms": {"field": col_field, "size": col_size}},
+                                },
+                            }
+                        },
+                    }
+                    response = service.client.search(
+                        index=service.index_name,
+                        body=body,
+                        request_cache=True,
+                        request_timeout=service.request_timeout,
+                    )
+                    row_agg = (response.get("aggregations") or {}).get("by_row") or {}
+                    buckets = row_agg.get("buckets") or []
+                    if not buckets:
+                        break
+                    found_any = True
+                    for rb in buckets:
+                        raw_key = ((rb.get("key") or {}).get("row_key"))
+                        values = {}
+                        for cb in (rb.get("by_col") or {}).get("buckets", []) or []:
+                            ck = cb.get("key")
+                            if ck is None:
+                                continue
+                            values[str(ck)] = cb.get("doc_count", 0)
+                        buffer_rows.append({"key": raw_key, "label": raw_key, "values": values})
+                        if len(buffer_rows) >= split_size:
+                            chunk_rows = builtins.list(buffer_rows[:split_size])
+                            del buffer_rows[:split_size]
+                            range_start = processed_rows + 1
+                            processed_rows += len(chunk_rows)
+                            range_end = processed_rows
+                            csv_content = _build_csv_content(
+                                dimension=dimension,
+                                columns=columns,
+                                rows=chunk_rows,
+                            )
+                            file_name = f"observation_{file_slug}_{int(time.time())}_part_{part_idx:03d}.csv"
+                            child_snapshot = _store_done_csv_job(
+                                dimension=dimension,
+                                file_name=file_name,
+                                csv_content=csv_content,
+                                total_rows=len(chunk_rows),
+                                parent_id=batch_job_id,
+                                sequence=part_idx,
+                                range_start=range_start,
+                                range_end=range_end,
+                            )
+                            with EXPORT_JOBS_LOCK:
+                                batch = EXPORT_JOBS.get(batch_job_id)
+                                if not batch:
+                                    break
+                                ready_ids = batch.get("ready_file_ids") or []
+                                ready_ids.append(child_snapshot["id"])
+                                batch["ready_file_ids"] = ready_ids
+                                batch["processed_rows"] = processed_rows
+                                batch["total_rows"] = estimated_total
+                                if estimated_total > 0:
+                                    batch["progress_percent"] = min(99, int((processed_rows * 100) / estimated_total))
+                                batch["message"] = _("Generating CSV files... %(processed)s/%(total)s") % {
+                                    "processed": processed_rows,
+                                    "total": estimated_total or processed_rows,
+                                }
+                                EXPORT_JOBS[batch_job_id] = batch
+                            part_idx += 1
+                    after_key = row_agg.get("after_key")
+                    if not after_key:
+                        break
+                if found_any:
+                    used_pair = (row_field, col_field)
+                    break
+                buffer_rows = []
+                processed_rows = 0
+                part_idx = 1
+            if used_pair:
+                break
+
+        if not used_pair or (processed_rows == 0 and not buffer_rows):
+            raise ValueError("No rows returned by backend for selected dimension and filters")
+
+        if buffer_rows:
+            chunk_rows = builtins.list(buffer_rows)
+            range_start = processed_rows + 1
+            processed_rows += len(chunk_rows)
+            range_end = processed_rows
+            csv_content = _build_csv_content(
+                dimension=dimension,
+                columns=columns,
+                rows=chunk_rows,
+            )
+            file_name = f"observation_{file_slug}_{int(time.time())}_part_{part_idx:03d}.csv"
+            child_snapshot = _store_done_csv_job(
+                dimension=dimension,
+                file_name=file_name,
+                csv_content=csv_content,
+                total_rows=len(chunk_rows),
+                parent_id=batch_job_id,
+                sequence=part_idx,
+                range_start=range_start,
+                range_end=range_end,
+            )
+            with EXPORT_JOBS_LOCK:
+                batch = EXPORT_JOBS.get(batch_job_id)
+                if batch:
+                    ready_ids = batch.get("ready_file_ids") or []
+                    ready_ids.append(child_snapshot["id"])
+                    batch["ready_file_ids"] = ready_ids
+                    EXPORT_JOBS[batch_job_id] = batch
+
+        with EXPORT_JOBS_LOCK:
+            batch = EXPORT_JOBS.get(batch_job_id)
+            if batch:
+                batch["status"] = "done"
+                batch["progress_percent"] = 100
+                batch["finished_at"] = int(time.time())
+                batch["message"] = _("All CSV files are ready")
+                batch["total_rows"] = max(estimated_total, processed_rows)
+                batch["processed_rows"] = processed_rows
+                EXPORT_JOBS[batch_job_id] = batch
+    except Exception as exc:
+        logger.exception("Async chunked export failed: %s", exc)
+        with EXPORT_JOBS_LOCK:
+            batch = EXPORT_JOBS.get(batch_job_id)
+            if batch:
+                batch["status"] = "error"
+                batch["finished_at"] = int(time.time())
+                batch["message"] = f"{type(exc).__name__}: {exc}"
+                batch["debug"] = traceback.format_exc(limit=6)
+                EXPORT_JOBS[batch_job_id] = batch
+
 @require_GET
 def list(request):
     index_name = _get_index_name(request)
     page = int(request.GET.get("page", 1))
     page_size = int(request.GET.get("limit", 25))
     text_search = request.GET.get("search", "")
-    query_clauses = _parse_query_clauses(request)
+    query_clauses = _parse_query_clauses_from_source(request.GET)
 
     try:
         service = SearchGatewayService(index_name=index_name)
@@ -183,68 +1114,18 @@ def filters(request):
 @require_GET
 def table(request):
     index_name = _get_index_name(request)
-    text_search = request.GET.get("search", "")
-    query_clauses = _parse_query_clauses(request)
 
     try:
         service = SearchGatewayService(index_name=index_name)
         if not service.data_source:
             return JsonResponse({"columns": [], "rows": [], "grand_total": 0})
-        applied_filters = extract_applied_filters(
-            request.GET,
-            service.data_source,
-            form_key=OBSERVATION_SEARCH_FORM_KEY,
-        )
-        selected_filters = normalize_option_filters(applied_filters)
-
         dimension = _resolve_observation_dimension(request) or {
             "row_field_name": "country",
             "col_field_name": "publication_year",
             "row_bucket_size": 500,
             "col_bucket_size": 300,
         }
-        field_settings = service.data_source.field_settings_dict or {}
-
-        row_field_name = dimension.get("row_field_name") or "country"
-        col_field_name = dimension.get("col_field_name") or "publication_year"
-        row_cfg = field_settings.get(row_field_name, {})
-        col_cfg = field_settings.get(col_field_name, {})
-        row_field = row_cfg.get("index_field_name")
-        col_field = col_cfg.get("index_field_name")
-        if not row_field or not col_field:
-            logger.warning(
-                "Observation table dimension has invalid field mapping: row=%s col=%s",
-                row_field_name,
-                col_field_name,
-            )
-            return JsonResponse({"columns": [], "rows": [], "grand_total": 0})
-
-        row_size = int(dimension.get("row_bucket_size") or row_cfg.get("filter", {}).get("size", 500))
-        col_size = int(dimension.get("col_bucket_size") or col_cfg.get("filter", {}).get("size", 300))
-        aggs = _build_nested_terms_aggs(
-            row_field=row_field,
-            col_field=col_field,
-            row_size=row_size,
-            col_size=col_size,
-        )
-
-        parse_config = {
-            "row_agg_name": "by_row",
-            "col_agg_name": "by_col",
-            "row_field_name": row_field_name,
-        }
-        row_transform = row_cfg.get("settings", {}).get("display_transform")
-        if row_transform:
-            parse_config["row_display_transform"] = row_transform
-
-        result = service.search_aggregation(
-            aggs=aggs,
-            query_text=text_search if not query_clauses else None,
-            query_clauses=query_clauses if query_clauses else None,
-            filters=selected_filters,
-            parse_config=parse_config,
-        )
-        result = _apply_lookup_labels_to_rows(service, row_field_name, result)
+        result = _build_dimension_table_result(request.GET, service, dimension)
         return JsonResponse(result)
     except Exception as e:
         logger.exception("Error in observation api_country_year_table: %s", e)
@@ -252,3 +1133,128 @@ def table(request):
             {"error": str(e), "columns": [], "rows": [], "grand_total": 0},
             status=500,
         )
+
+
+@require_GET
+def export_start(request):
+    index_name = _get_index_name(request)
+    page_id = request.GET.get("page_id")
+    scope = (request.GET.get("export_scope") or request.GET.get("scope") or "current").strip().lower()
+    batch_size = int(request.GET.get("batch_size", 1000))
+    progress_step = int(request.GET.get("progress_step", 100))
+    row_bucket_size = int(request.GET.get("row_bucket_size", 10000))
+    split_mode = str(request.GET.get("split_mode") or "").strip().lower() == "chunked"
+    split_size = max(1, int(request.GET.get("split_size", batch_size)))
+    jobs = []
+
+    service = SearchGatewayService(index_name=index_name)
+    if not service.data_source:
+        return JsonResponse({"error": "Invalid index_name"}, status=400)
+
+    # Download workflow is isolated from the table UI and runs for selected dimension.
+    dimensions = []
+    current = _resolve_observation_dimension(request)
+    if current:
+        dimensions = [current]
+    elif scope == "all" and page_id:
+        try:
+            page = ObservationPage.objects.get(id=int(page_id))
+        except (ObservationPage.DoesNotExist, TypeError, ValueError):
+            return JsonResponse({"error": "Invalid page_id"}, status=400)
+        default_dimension = page.get_default_dimension_config()
+        if default_dimension:
+            dimensions = [default_dimension]
+    if not dimensions:
+        return JsonResponse({"error": "No dimensions available"}, status=400)
+
+    for dimension in dimensions:
+        slug = dimension.get("slug") or ""
+        normalized_dimension = deepcopy(dimension)
+        normalized_dimension["row_bucket_size"] = row_bucket_size
+        query_source = request.GET.copy()
+        service = SearchGatewayService(index_name=index_name)
+
+        # "Generate all CSVs" must iterate through all records from backend,
+        # split by the selected limit (1000/2000), and create sequential files.
+        if split_mode:
+            batch_snapshot = _store_batch_job(
+                dimension=normalized_dimension,
+                message=_("Starting backend export..."),
+            )
+            worker = threading.Thread(
+                target=_run_chunked_export_async,
+                kwargs={
+                    "batch_job_id": batch_snapshot["id"],
+                    "dimension": normalized_dimension,
+                    "query_source": query_source,
+                    "index_name": index_name,
+                    "split_size": split_size,
+                },
+                daemon=True,
+            )
+            worker.start()
+            jobs.append(batch_snapshot)
+            continue
+
+        file_slug = slug or "dimension"
+        file_name = f"observation_{file_slug}_{int(time.time())}.csv"
+        file_job = _store_pending_csv_job(
+            dimension=normalized_dimension,
+            file_name=file_name,
+            message=_("Starting backend export..."),
+        )
+        worker = threading.Thread(
+            target=_run_export_job,
+            kwargs={
+                "job_id": file_job["id"],
+                "query_string": query_source.urlencode(),
+                "index_name": index_name,
+                "dimension": normalized_dimension,
+                "batch_size": batch_size,
+                "progress_step": progress_step,
+                "export_scope": scope,
+                "split_size": split_size,
+            },
+            daemon=True,
+        )
+        worker.start()
+        jobs.append(file_job)
+    return JsonResponse({"jobs": jobs})
+
+
+@require_GET
+def export_status(request, job_id):
+    with EXPORT_JOBS_LOCK:
+        job = EXPORT_JOBS.get(job_id)
+        if not job:
+            return JsonResponse({"error": "Job not found"}, status=404)
+        payload = {"job": _job_snapshot(job)}
+        if job.get("job_type") == "batch":
+            ready_jobs = []
+            for child_id in job.get("ready_file_ids") or []:
+                child = EXPORT_JOBS.get(child_id)
+                if child:
+                    ready_jobs.append(_job_snapshot(child))
+            payload["ready_jobs"] = ready_jobs
+    return JsonResponse(payload)
+
+
+@require_GET
+def export_download(request, job_id):
+    with EXPORT_JOBS_LOCK:
+        job = EXPORT_JOBS.get(job_id)
+    if not job:
+        return JsonResponse({"error": "Job not found"}, status=404)
+    if job.get("status") != "done":
+        return JsonResponse({"error": "Job is not ready yet"}, status=409)
+    csv_content = job.get("csv_content", "")
+    if not isinstance(csv_content, str) or not csv_content.strip():
+        fallback = StringIO()
+        fallback_writer = csv.writer(fallback)
+        fallback_writer.writerow([_("Message")])
+        fallback_writer.writerow([_("No data available for export")])
+        csv_content = fallback.getvalue()
+    response = HttpResponse(csv_content, content_type="text/csv; charset=utf-8")
+    response["Content-Disposition"] = f'attachment; filename="{job.get("file_name", "observation.csv")}"'
+    response["Cache-Control"] = "no-store"
+    return response


### PR DESCRIPTION
#### O que esse PR faz?
Implementa a área de download único em Observação, incluindo o fluxo completo de exportação com acompanhamento de status e endpoint de download.
Com isso, o usuário consegue iniciar exportações de forma mais clara e acompanhar o progresso até baixar o arquivo gerado.

#### Onde a revisão poderia começar?
Começar por `observation/static/observation/js/table.js`, que concentra o fluxo de exportação no front-end.
Depois revisar `observation/views.py` e `observation/urls.py`, onde estão os endpoints de start/status/download do processo.
Por fim, validar os ajustes de interface em `observation/templates/observation/include/table.html` e `observation/static/observation/css/table.css`.

#### Como este poderia ser testado manualmente?
1. Acesse a página de Observação.
2. Aplique filtros e inicie um download pela interface da tabela.
3. Verifique se o job de exportação é criado e aparece com status/progresso.
4. Aguarde a finalização e confirme que o botão/link de download fica disponível.
5. Faça o download do arquivo e valide conteúdo/consistência com os filtros aplicados.
6. Recarregue a página para validar persistência/recuperação do estado de exportações em andamento/concluídas.

#### Algum cenário de contexto que queira dar?

As mudanças melhoram a previsibilidade da experiência de exportação e reduzem fricção para datasets maiores, onde o processamento pode levar mais tempo.

### Screenshots

Tela incluída nesse PR: 

<img width="983" height="640" alt="Screenshot 2026-04-22 at 07 08 06" src="https://github.com/user-attachments/assets/6803163a-053a-4cb0-b2a8-4d30afe96050" />


#### Quais são tickets relevantes?
N/A

### Referências
N/A