### PR TITLE
Include backend to advance search in new template

### DIFF
--- a/search/advance_search.py
+++ b/search/advance_search.py
@@ -1,0 +1,289 @@
+import re
+from dataclasses import dataclass
+
+from django.utils.translation import gettext as _
+
+from search.choices import QUERY_STRING_FIELD_ALIASES
+
+
+OPERATORS = {"AND", "OR", "NOT"}
+VALUE_TOKEN_TYPES = {"TERM", "PHRASE"}
+INCOMPLETE_FIELD_FOLLOWERS = {None, "OPERATOR", "FIELD", ")"}
+INCOMPLETE_EXPRESSION_PREVIOUS_TYPES = {"FIELD", "OPERATOR", "("}
+
+
+class AdvancedQueryValidationError(ValueError):
+    """Raised when the user-provided advanced search expression is invalid."""
+
+
+@dataclass(frozen=True)
+class Token:
+    type: str
+    value: str
+
+
+def _allowed_advanced_query_fields():
+    return set(QUERY_STRING_FIELD_ALIASES) | set(QUERY_STRING_FIELD_ALIASES.values())
+
+
+def _normalize_field_name(field_name):
+    return QUERY_STRING_FIELD_ALIASES.get(field_name.lower(), field_name)
+
+
+def _raise_missing_operator_error():
+    raise AdvancedQueryValidationError(
+        _("Use AND, OR ou NOT para combinar termos na busca avançada.")
+    )
+
+
+class AdvancedQueryTokenizer:
+    field_pattern = re.compile(r"([A-Za-z_][\w.]*)\s*:")
+    term_pattern = re.compile(r"[^\s()]+")
+
+    def __init__(self, query_text):
+        self.query_text = query_text or ""
+        self.index = 0
+
+    def tokenize(self):
+        tokens = []
+        while not self._is_finished():
+            token = self._read_next_token()
+            if token is not None:
+                tokens.append(token)
+        return tokens
+
+    def _is_finished(self):
+        return self.index >= len(self.query_text)
+
+    def _read_next_token(self):
+        char = self.query_text[self.index]
+
+        if char.isspace():
+            self.index += 1
+            return None
+        if char == '"':
+            return self._read_phrase()
+        if char in "()":
+            self.index += 1
+            return Token(char, char)
+
+        field_token = self._read_field()
+        if field_token is not None:
+            return field_token
+        return self._read_term()
+
+    def _read_phrase(self):
+        start = self.index
+        self.index += 1
+        escaped = False
+
+        while not self._is_finished():
+            current = self.query_text[self.index]
+            if current == "\\" and not escaped:
+                escaped = True
+                self.index += 1
+                continue
+            if current == '"' and not escaped:
+                self.index += 1
+                return Token("PHRASE", self.query_text[start:self.index])
+            escaped = False
+            self.index += 1
+
+        raise AdvancedQueryValidationError(
+            _("A busca avançada contém aspas sem fechamento.")
+        )
+
+    def _read_field(self):
+        match = self.field_pattern.match(self.query_text, self.index)
+        if not match:
+            return None
+        self.index = match.end()
+        return Token("FIELD", match.group(1))
+
+    def _read_term(self):
+        match = self.term_pattern.match(self.query_text, self.index)
+        if not match:
+            self.index += 1
+            return None
+
+        term = match.group(0)
+        self.index = match.end()
+        operator = term.upper()
+        if operator in OPERATORS:
+            return Token("OPERATOR", operator)
+        return Token("TERM", term)
+
+
+class AdvancedQueryNormalizer:
+    def __init__(self, tokens):
+        self.tokens = tokens
+        self.allowed_fields = _allowed_advanced_query_fields()
+        self.parts = []
+        self.parentheses_depth = 0
+        self.expect_operand = True
+        self.previous_type = None
+        self.index = 0
+
+    def normalize(self):
+        while not self._is_finished():
+            self._consume_current_token()
+
+        self._validate_final_state()
+        return " ".join(self.parts)
+
+    def _is_finished(self):
+        return self.index >= len(self.tokens)
+
+    def _current_token(self):
+        return self.tokens[self.index]
+
+    def _next_type(self):
+        if self.index + 1 >= len(self.tokens):
+            return None
+        return self.tokens[self.index + 1].type
+
+    def _advance(self, steps=1):
+        self.index += steps
+
+    def _consume_current_token(self):
+        token = self._current_token()
+        handlers = {
+            "FIELD": self._consume_field,
+            "OPERATOR": self._consume_operator,
+            "(": self._consume_open_parenthesis,
+            ")": self._consume_close_parenthesis,
+        }
+        handler = handlers.get(token.type, self._consume_standalone_value)
+        handler(token)
+
+    def _consume_field(self, token):
+        if not self.expect_operand:
+            _raise_missing_operator_error()
+
+        self._validate_field_name(token.value)
+        self._validate_field_has_value(token.value)
+
+        if self._next_type() == "(":
+            self._consume_grouped_field(token.value)
+            return
+
+        value_tokens = self._collect_field_value_tokens()
+        self.parts.append(
+            f"{_normalize_field_name(token.value)}:{self._format_field_value(value_tokens)}"
+        )
+        self.expect_operand = False
+        self.previous_type = "TERM"
+
+    def _validate_field_name(self, field_name):
+        if field_name.lower() in self.allowed_fields:
+            return
+        raise AdvancedQueryValidationError(
+            _(f"Campo desconhecido na busca avançada: {field_name}")
+        )
+
+    def _validate_field_has_value(self, field_name):
+        if self._next_type() not in INCOMPLETE_FIELD_FOLLOWERS:
+            return
+        raise AdvancedQueryValidationError(
+            _(f"Informe um termo após o campo {field_name}.")
+        )
+
+    def _consume_grouped_field(self, field_name):
+        self.parentheses_depth += 1
+        self.parts.append(f"{_normalize_field_name(field_name)}:(")
+        self.expect_operand = True
+        self.previous_type = "("
+        self._advance(2)
+
+    def _collect_field_value_tokens(self):
+        value_tokens = []
+        self._advance()
+        while not self._is_finished() and self._current_token().type in VALUE_TOKEN_TYPES:
+            value_tokens.append(self._current_token())
+            self._advance()
+        return value_tokens
+
+    def _format_field_value(self, value_tokens):
+        if len(value_tokens) == 1:
+            return value_tokens[0].value
+        return f"({' '.join(token.value for token in value_tokens)})"
+
+    def _consume_operator(self, token):
+        if token.value in {"AND", "OR"} and self.expect_operand:
+            raise AdvancedQueryValidationError(
+                _("Operador %(operator)s em posição inválida.")
+                % {"operator": token.value}
+            )
+        if token.value == "NOT" and self._next_type() in {None, "OPERATOR", ")"}:
+            raise AdvancedQueryValidationError(
+                _("Informe um termo após o operador NOT.")
+            )
+
+        self.parts.append(token.value)
+        self.expect_operand = True
+        self.previous_type = token.type
+        self._advance()
+
+    def _consume_open_parenthesis(self, token):
+        if not self.expect_operand:
+            _raise_missing_operator_error()
+        if self._next_type() == ")":
+            raise AdvancedQueryValidationError(
+                _("A busca avançada contém parênteses vazios.")
+            )
+
+        self.parentheses_depth += 1
+        self.parts.append(token.value)
+        self.expect_operand = True
+        self.previous_type = token.type
+        self._advance()
+
+    def _consume_close_parenthesis(self, token):
+        self.parentheses_depth -= 1
+        if self.parentheses_depth < 0:
+            raise AdvancedQueryValidationError(
+                _("A busca avançada contém parêntese de fechamento sem abertura.")
+            )
+        if self.expect_operand or self.previous_type in INCOMPLETE_EXPRESSION_PREVIOUS_TYPES:
+            raise AdvancedQueryValidationError(
+                _("A busca avançada contém uma expressão incompleta antes de ')'.")
+            )
+
+        self.parts.append(token.value)
+        self.expect_operand = False
+        self.previous_type = token.type
+        self._advance()
+
+    def _consume_standalone_value(self, token):
+        if not self.expect_operand:
+            _raise_missing_operator_error()
+
+        self.parts.append(token.value)
+        self.expect_operand = False
+        self.previous_type = token.type
+        self._advance()
+
+    def _validate_final_state(self):
+        if self.parentheses_depth:
+            raise AdvancedQueryValidationError(
+                _("A busca avançada contém parênteses sem fechamento.")
+            )
+        if self.expect_operand or self.previous_type in INCOMPLETE_EXPRESSION_PREVIOUS_TYPES:
+            raise AdvancedQueryValidationError(
+                _("A busca avançada termina com uma expressão incompleta.")
+            )
+
+
+def normalize_advanced_query(query_text):
+    cleaned_query = (query_text or "").strip()
+    if not cleaned_query:
+        return ""
+
+    tokens = AdvancedQueryTokenizer(cleaned_query).tokenize()
+    if not tokens:
+        return ""
+    return AdvancedQueryNormalizer(tokens).normalize()
+
+
+def validate_advanced_query(query_text):
+    normalize_advanced_query(query_text)

--- a/search/choices.py
+++ b/search/choices.py
@@ -148,14 +148,35 @@ SEARCH_FIELD_MAPPING = {
 
 # Aliases for query_string: user-friendly name -> index field
 QUERY_STRING_FIELD_ALIASES = {
+    "ti": "title_search",
     "title": "title_search",
+    "ab": "abstract",
     "abstract": "abstract",
+    "kw": "subjects_search",
     "ids": "ids_search",
+    "doi": "ids_search",
+    "issn": "ids_search",
+    "isbn": "ids_search",
+    "au": "authors_search",
     "authors": "authors_search",
     "subjects": "subjects_search",
+    "subject": "subjects_search",
     "publishers": "publishers_search",
+    "publisher": "publishers_search",
     "sources": "sources_search",
+    "source": "sources_search",
     "institutions": "institutions_search",
+    "institution": "institutions_search",
+    "aff_institution": "institutions_search",
+    "aff_country": "author_country_codes",
+    "institution_title": "institutions_search",
+    "institution_country": "author_country_codes",
+    "journal_title": "sources_search",
+    "source_type": "sources.type",
+    "source_country": "oca_data.source.country_search",
+    "publication_year": "publication_year",
+    "is_open_access": "is_open_access",
+    "funder": "funders.id",
 }
 
 QUERY_STRING_FIELDS = list(

--- a/search/models.py
+++ b/search/models.py
@@ -14,6 +14,7 @@ from search_gateway.option_normalization import (
     normalize_positive_number,
     normalize_search_result_sort,
 )
+from .advance_search import AdvancedQueryValidationError
 from search_gateway.request_filters import (
     extract_applied_filters,
     normalize_option_filters,
@@ -79,7 +80,8 @@ class SearchPage(Page):
             current_sort,
         )
         return {
-            "search_query": request.GET.get("search", ""),
+            "search_query": request.GET.get("search", "").strip(),
+            "advanced_search_query": request.GET.get("advanced_search", "").strip(),
             "query_clauses": cls.query_clauses(request),
             "current_sort": current_sort,
             "sort_field": sort_field,
@@ -161,6 +163,7 @@ class SearchPage(Page):
         index_name="",
         search_sidebar_html="",
         results_data=None,
+        advanced_search_error="",
     ):
         scientific_index = getattr(settings, "OP_INDEX_SCIENTIFIC_PRODUCTION", "scientific_production")
         payload = {"search_results": [], "total_results": 0} if results_data is None else results_data
@@ -170,6 +173,8 @@ class SearchPage(Page):
             "search_clauses": request_state["query_clauses"],
             "is_scientific_data_source": index_name == scientific_index,
             "search_query": request_state["search_query"],
+            "advanced_search_query": request_state["advanced_search_query"],
+            "advanced_search_error": advanced_search_error,
             "search_sidebar_html": search_sidebar_html,
             "results_data": payload,
             "citation_documents": cls.build_citation_documents(payload.get("search_results")),
@@ -192,7 +197,13 @@ class SearchPage(Page):
     def fetch_gateway_search_results(self, data_source, request_state, selected_filters):
         service = SearchGatewayService(index_name=data_source.index_name)
         return service.search_documents(
-            query_text=request_state["search_query"] if not request_state["query_clauses"] else None,
+            query_text=(
+                request_state["search_query"]
+                if not request_state["query_clauses"]
+                and not request_state["advanced_search_query"]
+                else None
+            ),
+            advanced_query=request_state["advanced_search_query"],
             query_clauses=request_state["query_clauses"],
             filters=selected_filters,
             page=request_state["current_page"],
@@ -214,7 +225,12 @@ class SearchPage(Page):
         applied_filters = extract_applied_filters(request.GET, data_source, form_key="search")
         selected_filters = normalize_option_filters(applied_filters)
         sidebar_html = self.render_search_filter_sidebar_html(request, data_source, applied_filters)
-        raw_results = self.fetch_gateway_search_results(data_source, request_state, selected_filters)
+        advanced_search_error = ""
+        try:
+            raw_results = self.fetch_gateway_search_results(data_source, request_state, selected_filters)
+        except AdvancedQueryValidationError as exc:
+            advanced_search_error = str(exc)
+            raw_results = {"search_results": [], "total_results": 0}
         results_data = self.current_pagination(
             raw_results,
             page=request_state["current_page"],
@@ -227,6 +243,7 @@ class SearchPage(Page):
                 index_name=data_source.index_name,
                 search_sidebar_html=sidebar_html,
                 results_data=results_data,
+                advanced_search_error=advanced_search_error,
             )
         )
         return context

--- a/search/static/search/css/custom.css
+++ b/search/static/search/css/custom.css
@@ -120,13 +120,22 @@
 .search-input-card__row,
 .advanced-search-row {
   display: grid;
-  grid-template-columns: 7.9rem minmax(9.6rem, 0.9fr) minmax(15rem, 1.35fr) 2.2rem;
+  grid-template-columns: 4.4rem 14rem minmax(15rem, 1fr) 2.2rem;
   align-items: center;
   gap: 0.65rem;
 }
 
 .advanced-search-row[data-row-index="0"] {
-  grid-template-columns: minmax(8.3rem, 0.62fr) minmax(0, 2fr);
+  grid-template-columns: 4.4rem 14rem minmax(15rem, 1fr) 2.2rem;
+}
+
+.advanced-search-row[data-row-index="0"] .search-field-select {
+  grid-column: 1 / 3;
+  width: 100%;
+}
+
+.advanced-search-row[data-row-index="0"] .search-text-input {
+  grid-column: 3 / 5;
 }
 
 .search-header-card .search-field-select,
@@ -172,17 +181,22 @@
 }
 
 .advanced-search-row .search-operator {
-  width: 7.9rem;
-  max-width: 7.9rem;
+  width: 4.4rem;
+  max-width: 4.4rem;
+  padding-right: 1.25rem;
+  padding-left: 0.65rem;
+  background-position: right 0.45rem center;
   border-width: 1px;
   border-color: #d8e3f0;
   color: #2f5ac2;
   font-weight: 700;
-  background: #f7faff;
+  background-color: #f7faff;
 }
 
 .advanced-search-row .search-field-select {
   min-width: 0;
+  width: 100%;
+  max-width: 100%;
 }
 
 .advanced-search-row .search-text-input {

--- a/search/static/search/css/search_mode.css
+++ b/search/static/search/css/search_mode.css
@@ -90,6 +90,18 @@
   margin-bottom: 0.72rem;
 }
 
+.advanced-search-input--invalid {
+  border-color: #dc3545 !important;
+  background: #fff8f8 !important;
+}
+
+.advanced-search-error {
+  margin-top: 0.45rem;
+  color: #b42318;
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
 #advanced-guide-wrapper {
   margin-top: 1.25rem;
   margin-bottom: 1rem;

--- a/search/static/search/js/search_page/results_api.js
+++ b/search/static/search/js/search_page/results_api.js
@@ -14,12 +14,20 @@
     buildSearchParams() {
       const params = new URLSearchParams();
       const state = this.ctx.state;
-      const clauses = this.ctx.searchForm.getSearchClauses();
 
-      if (clauses.length > 0) {
-        params.set('search_clauses', JSON.stringify(clauses));
-      } else if (state.searchQuery) {
-        params.set('search', state.searchQuery);
+      if (this.ctx.searchForm.getActiveSearchMode() === 'advanced') {
+        const advancedQuery = this.ctx.searchForm.getAdvancedSearchQuery();
+        state.advancedSearchQuery = advancedQuery;
+        if (advancedQuery) {
+          params.set('advanced_search', advancedQuery);
+        }
+      } else {
+        const clauses = this.ctx.searchForm.getSearchClauses();
+        if (clauses.length > 0) {
+          params.set('search_clauses', JSON.stringify(clauses));
+        } else if (state.searchQuery) {
+          params.set('search', state.searchQuery);
+        }
       }
 
       if (state.dataSourceName) {
@@ -108,9 +116,17 @@
 
       try {
         const response = await fetch(`${state.apiEndpoint}?${params.toString()}`, { signal });
-        if (!response.ok) throw new Error('Network response was not ok');
         const data = await response.json();
 
+        if (!response.ok) {
+          if (response.status === 400 && data.error_type === 'advanced_query') {
+            this.ctx.searchForm.showAdvancedSearchError(data.error);
+            return;
+          }
+          throw new Error(data.error || 'Network response was not ok');
+        }
+
+        this.ctx.searchForm.clearAdvancedSearchError();
         this.renderResultsFragments(data);
         state.syncCitationDocuments(data.citation_documents);
         this.ctx.resultsUi.setupResultsUi();

--- a/search/static/search/js/search_page/search_form.js
+++ b/search/static/search/js/search_page/search_form.js
@@ -12,6 +12,7 @@
       this.advancedContainer = document.getElementById('search-mode-advanced-container');
       this.guideWrapper = document.getElementById('advanced-guide-wrapper');
       this.advancedInput = document.getElementById('advanced-search-input');
+      this.advancedError = document.getElementById('advanced-search-error');
       this.extraRows = document.getElementById('advanced-search-rows');
     }
 
@@ -70,6 +71,26 @@
       this.guideWrapper.style.display = activeMode === 'advanced' ? 'block' : 'none';
     }
 
+    showAdvancedSearchError(message) {
+      this.ctx.state.advancedSearchError = message || '';
+      if (!this.advancedError || !this.advancedInput) return;
+
+      this.advancedError.textContent = this.ctx.state.advancedSearchError;
+      this.advancedError.hidden = !this.ctx.state.advancedSearchError;
+      this.advancedInput.classList.toggle(
+        'advanced-search-input--invalid',
+        Boolean(this.ctx.state.advancedSearchError),
+      );
+      this.advancedInput.setAttribute(
+        'aria-invalid',
+        this.ctx.state.advancedSearchError ? 'true' : 'false',
+      );
+    }
+
+    clearAdvancedSearchError() {
+      this.showAdvancedSearchError('');
+    }
+
     toggleSyntaxGuide(button) {
       const guide = document.getElementById('advanced-search-guide');
 
@@ -78,24 +99,42 @@
       this.searchForm.classList.toggle('search-header-card__search--with-guide');
     }
 
+    getAdvancedSearchQuery() {
+      return this.advancedInput ? this.advancedInput.value.trim() : '';
+    }
+
     syncSearchStateFromForm() {
+      this.clearAdvancedSearchError();
+
       if (this.getActiveSearchMode() === 'advanced') {
         this.ctx.state.searchClauses = [];
-        this.ctx.state.searchQuery = this.advancedInput.value.trim();
+        this.ctx.state.searchQuery = '';
+        this.ctx.state.advancedSearchQuery = this.getAdvancedSearchQuery();
         return;
       }
 
       this.ctx.state.searchClauses = this.getSearchClauses();
       this.ctx.state.searchQuery = '';
+      this.ctx.state.advancedSearchQuery = '';
     }
 
     restoreSearchClauses() {
       const clauses = this.ctx.state.searchClauses;
       const query = this.ctx.state.searchQuery;
+      const advancedQuery = this.ctx.state.advancedSearchQuery;
+
+      if (advancedQuery) {
+        this.advancedInput.value = advancedQuery;
+        this.setSearchMode('advanced');
+        this.showAdvancedSearchError(this.ctx.state.advancedSearchError);
+        return;
+      }
 
       if (query && (!clauses || clauses.length === 0)) {
-        this.advancedInput.value = (query === '*' || query === 'all') ? '' : query;
-        this.setSearchMode('advanced');
+        const firstRow = document.querySelector('.advanced-search-row[data-row-index="0"]');
+        const text = (query === '*' || query === 'all') ? '' : query;
+        this.setRowValues(firstRow, { field: 'all', text });
+        this.setSearchMode('by_field');
         return;
       }
 
@@ -173,7 +212,9 @@
 
     clearSearchQuery() {
       this.ctx.state.searchQuery = '';
+      this.ctx.state.advancedSearchQuery = '';
       this.ctx.state.searchClauses = [];
+      this.clearAdvancedSearchError();
 
       this.advancedInput.value = '';
 

--- a/search/static/search/js/search_page/state.js
+++ b/search/static/search/js/search_page/state.js
@@ -10,6 +10,8 @@
 
       this.config = config || {};
       this.searchQuery = this.config.initialSearchQuery || '';
+      this.advancedSearchQuery = this.config.initialAdvancedSearchQuery || '';
+      this.advancedSearchError = this.config.initialAdvancedSearchError || '';
       this.searchClauses = this.config.initialSearchClauses || [];
       this.dataSourceName = this.config.dataSourceName || '';
       this.csrfToken = this.config.csrfToken || '';

--- a/search/templates/search/include/search/advanced.html
+++ b/search/templates/search/include/search/advanced.html
@@ -5,7 +5,9 @@
     <input type="search" id="advanced-search-input"
         class="search-input-card__input search-text-input advanced-search-input"
         placeholder="{% trans 'Ex: title: &quot;Ciência Aberta&quot; AND publication_year: 2025' %}"
+        aria-describedby="advanced-search-error"
         autocomplete="off" value="">
+    <div id="advanced-search-error" class="advanced-search-error" role="alert" aria-live="polite" hidden></div>
 </div>
 
 <div class="search-header-card__footer">

--- a/search/templates/search/include/search/advanced_guide.html
+++ b/search/templates/search/include/search/advanced_guide.html
@@ -19,31 +19,31 @@
                 <div class="advanced-search-guide__fields-group">
                     <h5 class="advanced-search-guide__group-title">{% trans "DOCUMENTO" %}</h5>
                     <ul class="advanced-search-guide__field-list">
-                        <li><span class="field-key">title</span><span class="field-desc">{% trans "Título do documento" %}</span></li>
-                        <li><span class="field-key">abstract</span><span class="field-desc">{% trans "Resumo" %}</span></li>
-                        <li><span class="field-key">keyword</span><span class="field-desc">{% trans "Palavras-chave" %}</span></li>
+                        <li><span class="field-key">ti</span><span class="field-desc">{% trans "Título do documento" %}</span></li>
+                        <li><span class="field-key">ab</span><span class="field-desc">{% trans "Resumo" %}</span></li>
+                        <li><span class="field-key">kw</span><span class="field-desc">{% trans "Palavras-chave" %}</span></li>
+                        <li><span class="field-key">ids</span><span class="field-desc">{% trans "DOI, ISBN, identificadores" %}</span></li>
                         <li><span class="field-key">is_open_access</span><span class="field-desc">{% trans "Acesso aberto (true/false)" %}</span></li>
                         <li><span class="field-key">publication_year</span><span class="field-desc">{% trans "Ano de publicação" %}</span></li>
                         <li><span class="field-key">doi</span><span class="field-desc">{% trans "Código DOI" %}</span></li>
+                        <li><span class="field-key">issn</span><span class="field-desc">{% trans "ISSN de periódico" %}</span></li>
+                        <li><span class="field-key">isbn</span><span class="field-desc">{% trans "ISBN de livro" %}</span></li>
                     </ul>
                 </div>
                 <div class="advanced-search-guide__fields-group">
                     <h5 class="advanced-search-guide__group-title">{% trans "AUTORIA E INSTITUIÇÃO" %}</h5>
                     <ul class="advanced-search-guide__field-list">
-                        <li><span class="field-key">author</span><span class="field-desc">{% trans "Autor do documento" %}</span></li>
-                        <li><span class="field-key">institution_title</span><span class="field-desc">{% trans "Nome da instituição" %}</span></li>
-                        <li><span class="field-key">institution_country</span><span class="field-desc">{% trans "País da instituição" %}</span></li>
+                        <li><span class="field-key">au</span><span class="field-desc">{% trans "Autor do documento" %}</span></li>
+                        <li><span class="field-key">aff_institution</span><span class="field-desc">{% trans "Nome da instituição" %}</span></li>
+                        <li><span class="field-key">aff_country</span><span class="field-desc">{% trans "País da instituição" %}</span></li>
                     </ul>
                 </div>
                 <div class="advanced-search-guide__fields-group">
                     <h5 class="advanced-search-guide__group-title">{% trans "FONTE" %}</h5>
                     <ul class="advanced-search-guide__field-list">
-                        <li><span class="field-key">source_title</span><span class="field-desc">{% trans "Nome do periódico ou livro" %}</span></li>
+                        <li><span class="field-key">journal_title</span><span class="field-desc">{% trans "Nome do periódico ou livro" %}</span></li>
                         <li><span class="field-key">publisher</span><span class="field-desc">{% trans "Casa publicadora" %}</span></li>
                         <li><span class="field-key">source_type</span><span class="field-desc">{% trans "Tipo de fonte" %}</span></li>
-                        <li><span class="field-key">source_country</span><span class="field-desc">{% trans "País da fonte" %}</span></li>
-                        <li><span class="field-key">issn</span><span class="field-desc">{% trans "ISSN de periódico" %}</span></li>
-                        <li><span class="field-key">isbn</span><span class="field-desc">{% trans "ISBN de livro" %}</span></li>
                     </ul>
                 </div>
                 <div class="advanced-search-guide__fields-group">

--- a/search/templates/search/include/search/by_field.html
+++ b/search/templates/search/include/search/by_field.html
@@ -21,6 +21,7 @@
             <span class="search-header-card__action-link-icon plus-icon" aria-hidden="true"></span>
             <span>{% trans "Adicionar campo" %}</span>
         </button>
+        <button type="button" class="search-header-card__clear" id="btn-clear">{% trans "Limpar" %}</button>
     </div>
     <button type="submit" class="search-header-card__submit">
         {% trans "Pesquisar" %}

--- a/search/templates/search/search_page.html
+++ b/search/templates/search/search_page.html
@@ -44,6 +44,8 @@
 <script>
     window.searchPageConfig = {
         initialSearchQuery: '{{ search_query|escapejs }}',
+        initialAdvancedSearchQuery: '{{ advanced_search_query|escapejs }}',
+        initialAdvancedSearchError: '{{ advanced_search_error|escapejs }}',
         initialSearchClauses: JSON.parse(document.getElementById('search-clauses-data').textContent),
         dataSourceName: '{{ index_name|escapejs }}',
         csrfToken: '{{ csrf_token }}',

--- a/search/views.py
+++ b/search/views.py
@@ -5,6 +5,7 @@ from django.http import JsonResponse
 from django.template.loader import render_to_string
 from django.views.decorators.http import require_GET
 
+from .advance_search import AdvancedQueryValidationError
 from search_gateway.request_filters import (
     extract_applied_filters,
     normalize_option_filters,
@@ -12,22 +13,6 @@ from search_gateway.request_filters import (
 from search_gateway.service import SearchGatewayService
 
 from .models import SearchPage
-
-
-def _applied_filters_for_json(applied_filters):
-    """Expose server-side applied filters (incl. operators) for the client without re-rendering the sidebar."""
-    result = {}
-    for key, value in (applied_filters or {}).items():
-        if str(key).startswith("__"):
-            continue
-        if isinstance(value, (list, tuple)):
-            cleaned = [str(item) for item in value if item not in (None, "")]
-            if not cleaned:
-                continue
-            result[key] = cleaned if len(cleaned) > 1 else cleaned[0]
-        elif value not in (None, ""):
-            result[key] = str(value)
-    return result
 
 
 def _render_results_fragments(request, results_data):
@@ -71,7 +56,13 @@ def search_view_list(request):
         applied_filters = extract_applied_filters(request.GET, data_source, form_key="search")
         selected_filters = normalize_option_filters(applied_filters)
         results_data = service.search_documents(
-            query_text=request_state["search_query"] if not request_state["query_clauses"] else None,
+            query_text=(
+                request_state["search_query"]
+                if not request_state["query_clauses"]
+                and not request_state["advanced_search_query"]
+                else None
+            ),
+            advanced_query=request_state["advanced_search_query"],
             query_clauses=request_state["query_clauses"],
             filters=selected_filters,
             page=request_state["current_page"],
@@ -92,6 +83,8 @@ def search_view_list(request):
                 results_data.get("search_results")
             ),
         })
+    except AdvancedQueryValidationError as e:
+        return JsonResponse({"error": str(e), "error_type": "advanced_query"}, status=400)
     except Exception as e:
         logging.exception(f"Error getting filters for index {index_name}. {e}")
         return JsonResponse({"error": str(e)}, status=500)

--- a/search_gateway/query.py
+++ b/search_gateway/query.py
@@ -1,10 +1,6 @@
-import re
 
-from search.choices import (
-    QUERY_STRING_FIELD_ALIASES,
-    QUERY_STRING_FIELDS,
-    SEARCH_FIELD_MAPPING,
-)
+from search.advance_search import normalize_advanced_query
+from search.choices import SEARCH_FIELD_MAPPING
 
 
 def _escape_wildcard_chars(text):
@@ -34,13 +30,13 @@ def build_terms_clause(field_name, values):
 
 def query_filters(filters):
     """
-    Build filter clauses for Elasticsearch query.
+    Build filter clauses for opensearch query.
 
-    Note: Filters should already have Elasticsearch field names as keys
+    Note: Filters should already have opensearch field names as keys
     (i.e., already mapped from form field names).
 
     Args:
-        filters: Dict of filters with Elasticsearch field names as keys.
+        filters: Dict of filters with opensearch field names as keys.
 
     Returns:
         List of filter clauses for the bool query.
@@ -208,57 +204,27 @@ def build_filters_aggs(field_settings, exclude_fields=None):
     return aggs
 
 
-def _is_advanced_query(text):
-    """Detect if text contains advanced query syntax (field:value, OR, AND, parentheses)."""
-    if not text or not isinstance(text, str):
-        return False
-    t = text.strip()
-    if re.search(r"\w+:\S+", t):
-        return True
-    if re.search(r"\b(OR|AND|NOT)\b", t, re.IGNORECASE):
-        return True
-    if "(" in t or ")" in t:
-        return True
-    return False
-
-
-def _rewrite_field_aliases_in_query(query_text):
-    """Rewrite user-friendly field names to index field names in the query string."""
-    result = query_text
-    for alias, index_field in sorted(
-        QUERY_STRING_FIELD_ALIASES.items(), key=lambda x: -len(x[0])
-    ):
-        result = re.sub(
-            rf"\b{re.escape(alias)}\s*:",
-            f"{index_field}:",
-            result,
-            flags=re.IGNORECASE,
-        )
-    return result
-
-
 def _build_advanced_query(query_text):
     """Build a query_string query for advanced syntax like (title:covid OR abstract:covid)."""
-    rewritten = _rewrite_field_aliases_in_query(query_text)
+    rewritten = normalize_advanced_query(query_text)
     return {
         "query_string": {
             "query": rewritten,
-            "fields": QUERY_STRING_FIELDS,
+            "fields": ["title_search"],
             "default_operator": "AND",
+            "lenient": True,
         }
     }
 
 
 def _build_clause_query(field_key, query_text):
-    """Build a clause for a given field and text. Uses query_string if advanced syntax detected."""
-    if _is_advanced_query(query_text):
-        return _build_advanced_query(query_text)
+    """Build a simple text clause for a given field without advanced syntax parsing."""
     fields = SEARCH_FIELD_MAPPING.get(field_key, ["title_search", "ids_search"])
     return {
-        "simple_query_string": {
+        "multi_match": {
             "query": query_text,
-            "default_operator": "AND",
             "fields": fields,
+            "operator": "and",
         }
     }
 
@@ -369,6 +335,7 @@ def build_search_text_body(query_text):
 
 def build_document_search_body(
         query_text=None,
+        advanced_query=None,
         query_clauses=None,
         filters=None,
         page=1,
@@ -382,6 +349,7 @@ def build_document_search_body(
 
     Args:
         query_text: Text to search for (legacy, used when query_clauses is empty).
+        advanced_query: Query string syntax submitted from the advanced search input.
         query_clauses: List of {operator, field, text} for advanced search.
         filters: Dict of filters (should already be mapped to ES field names).
         page: Page number (1-based).
@@ -395,6 +363,7 @@ def build_document_search_body(
     """
     bool_query = build_bool_query_from_search_params(
         query_text=query_text,
+        advanced_query=advanced_query,
         query_clauses=query_clauses,
         filters=filters,
     )
@@ -419,6 +388,7 @@ def build_document_search_body(
 
 def build_bool_query_from_search_params(
     query_text=None,
+    advanced_query=None,
     query_clauses=None,
     filters=None,
 ):
@@ -426,17 +396,20 @@ def build_bool_query_from_search_params(
     Bool query fragment (must / must_not / filter) shared by document search and
     aggregations. ``filters`` must already use OpenSearch index field names.
     """
-    if query_clauses:
+    advanced_query = (advanced_query or "").strip()
+    if advanced_query:
+        bool_query = {"must": [_build_advanced_query(advanced_query)]}
+    elif query_clauses:
         bool_query = build_bool_from_clauses(query_clauses)
     else:
         bool_query = {"must": []}
         if query_text:
             bool_query["must"].append(
                 {
-                    "simple_query_string": {
+                    "multi_match": {
                         "query": query_text,
-                        "default_operator": "AND",
                         "fields": ["title_search", "ids_search"],
+                        "operator": "and",
                     },
                 }
             )

--- a/search_gateway/request_filters.py
+++ b/search_gateway/request_filters.py
@@ -13,6 +13,7 @@ DEFAULT_EXCLUDED_QUERY_KEYS = frozenset(
     {
         "csrfmiddlewaretoken",
         "search",
+        "advanced_search",
         "search_clauses",
         "page",
         "limit",

--- a/search_gateway/service.py
+++ b/search_gateway/service.py
@@ -288,6 +288,7 @@ class SearchGatewayService:
     def search_documents(
         self,
         query_text=None,
+        advanced_query=None,
         query_clauses=None,
         filters=None,
         page=1,
@@ -301,6 +302,7 @@ class SearchGatewayService:
         mapped_filters = get_mapped_filters(filters, self.field_settings)
         body = build_document_search_body(
             query_text=query_text,
+            advanced_query=advanced_query,
             query_clauses=query_clauses,
             filters=mapped_filters,
             page=page,
@@ -322,6 +324,7 @@ class SearchGatewayService:
         self,
         aggs,
         query_text=None,
+        advanced_query=None,
         query_clauses=None,
         filters=None,
         parse_config=None,
@@ -332,6 +335,7 @@ class SearchGatewayService:
         Args:
             aggs: Aggregation definition dict (e.g. {"by_country": {...}}).
             query_text: Text search (same as search_documents).
+            advanced_query: Query string syntax (same as search_documents).
             query_clauses: Advanced search clauses (same as search_documents).
             filters: Selected filters, form field names (same as search_documents).
             parse_config: Optional dict for parse_aggregation_response.
@@ -344,6 +348,7 @@ class SearchGatewayService:
         mapped_filters = get_mapped_filters(filters or {}, field_settings)
         bool_query = build_bool_query_from_search_params(
             query_text=query_text,
+            advanced_query=advanced_query,
             query_clauses=query_clauses,
             filters=mapped_filters,
         )


### PR DESCRIPTION
#### O que esse PR faz?
Este PR implementa o backend e a integração com o novo template de busca avançada na página de search.
Ele adiciona um parser próprio para a busca avançada, com tokenizer e normalizer, permitindo interpretar campos como ti, ab, kw, au, aff_institution, operadores lógicos como AND, OR, NOT, frases com aspas e agrupamentos com parênteses. Também separa a busca simples da busca avançada usando o parâmetro advanced_query, evitando que o campo de busca simples interprete operadores avançados por acidente.

Além disso, o PR adiciona validações para expressões inválidas, mapeia aliases de campos para os campos reais do OpenSearch, ajusta o JavaScript do formulário, atualiza o guia de sintaxe e adiciona estilos para o novo campo/erro da busca avançada.

#### Onde a revisão poderia começar?
A revisão pode começar por:

```search/advance_search.py```

Esse arquivo concentra a lógica principal da busca avançada, incluindo tokenização, validação e normalização da query digitada pelo usuário.

Depois, recomendo revisar:

```search_gateway/query.py```

Esse arquivo mostra como a query avançada normalizada é convertida para uma query do OpenSearch e como ela se integra com a busca simples e os filtros.

Por fim, revisar a integração com a UI em:

```
search/static/search/js/search_page/search_form.js
search/static/search/js/search_page/results_api.js
search/templates/search/include/search/advanced.html
```

#### Como este poderia ser testado manualmente?
1. Acessar a página de busca.
2. Usar o modo de busca simples por campo e confirmar que termos como AND, OR, ti: ou parênteses são tratados como texto normal.
3. Alternar para busca avançada.
4. Testar uma busca por título, por exemplo:
```ti:ECONOMIAS DE ESCALA E A COMPETITIVIDADE```
Testar uma frase com aspas:
```ti:"ECONOMIAS DE ESCALA E A COMPETITIVIDADE"```
Testar combinações com operadores:
```ti:covid AND au:Silva```
Testar uma query inválida, por exemplo:
```ti:covid AND OR au:Silva```
O esperado é que a interface mostre uma mensagem de erro amigável, sem quebrar a busca.

#### Algum cenário de contexto que queira dar?
A busca avançada antes dependia de lógica misturada com a busca textual simples. Isso dificultava separar o comportamento esperado de cada campo e fazia com que operadores digitados no campo simples pudessem alterar a semântica da busca.

Este PR cria uma camada dedicada para interpretar a busca avançada e mantém a busca simples como texto comum. Isso deixa o comportamento mais previsível para o usuário e facilita evoluções futuras de sintaxe.

