### PR TITLE
Mantém botão filtrar visível ao rolar página para baixo ou para cima 

### DIFF
--- a/search_gateway/static/search_gateway/css/filter_sidebar.css
+++ b/search_gateway/static/search_gateway/css/filter_sidebar.css
@@ -16,7 +16,6 @@
   background: var(--sg-surface);
   border-radius: 6px;
   box-shadow: var(--sg-shadow);
-  overflow: hidden;
 }
 
 .sg-filter-sidebar__head {
@@ -27,6 +26,11 @@
   padding: 1.05rem 1.35rem 0.9rem;
   border-bottom: 1px solid #ebf0f6;
   background: var(--sg-surface);
+  position: sticky;
+  top: var(--sg-header-offset, 0px);
+  z-index: 10;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
 }
 
 .sg-filter-sidebar__title {

--- a/search_gateway/static/search_gateway/js/filter_form.js
+++ b/search_gateway/static/search_gateway/js/filter_form.js
@@ -1252,6 +1252,47 @@
     }));
   }
 
+  function syncFilterSidebarStickyOffset() {
+    const sidebarHead = document.querySelector('.sg-filter-sidebar__head');
+    if (!sidebarHead) return;
+
+    const headerWrap = document.querySelector('#header-wrap') || document.querySelector('#header');
+    if (!headerWrap) return;
+
+    const bottom = headerWrap.getBoundingClientRect().bottom;
+    const offset = Math.max(0, bottom);
+    document.documentElement.style.setProperty('--sg-header-offset', `${offset}px`);
+  }
+
+  function initStickySidebarOffset() {
+    let syncTimer = null;
+    let isSyncing = false;
+
+    function syncLoop() {
+      syncFilterSidebarStickyOffset();
+      if (isSyncing) {
+        window.requestAnimationFrame(syncLoop);
+      }
+    }
+
+    function handleScroll() {
+      if (!isSyncing) {
+        isSyncing = true;
+        window.requestAnimationFrame(syncLoop);
+      }
+      clearTimeout(syncTimer);
+      syncTimer = setTimeout(() => {
+        isSyncing = false;
+        // One final sync to ensure pixel-perfect end state
+        syncFilterSidebarStickyOffset();
+      }, 500);
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', syncFilterSidebarStickyOffset, { passive: true });
+    syncFilterSidebarStickyOffset();
+  }
+
   async function init(root) {
     const container = root || document;
     initCollapsibleFilterGroups(container);
@@ -1264,6 +1305,7 @@
     bindNativeResetHandling(container);
     bindAppliedFiltersSummary(container);
     bindSelectPlaceholderState(container);
+    initStickySidebarOffset();
     await lookupPromise;
     getFilterForms(container).forEach(commitAppliedFilters);
     dispatchFiltersReady(container);


### PR DESCRIPTION
#### O que esse PR faz?
Melhora comportamento do botão filtrar fazendo com que permaneça visível parte superior da barra de filtros quando o usuário rolar a página para baixo (ou para cima). O comportamento, por causa do "header" móvel, é ajustado via Javascript.

#### Onde a revisão poderia começar?
N/A

#### Como este poderia ser testado manualmente?
- Abra a página de busca
- Role a página para baixo
- Observe o botão filtrar permanecendo na parte superior da tela
- Role a página para cima
- Observe o botão filtrar permanecendo na parte superior da tela

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
<img width="1085" height="826" alt="image" src="https://github.com/user-attachments/assets/3d97f958-9619-431d-8edd-c2bd66331870" />

<img width="745" height="522" alt="image" src="https://github.com/user-attachments/assets/5d67bcad-3d18-4e15-b9c2-5b2d8d43c6b7" />


#### Quais são tickets relevantes?
#628 

### Referências
N/A
