### PR TITLE
remove entrada que permitia env local compor commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,4 +281,3 @@ core/media/
 .ipython/
 .env
 .envs/*
-!.envs/.local/


### PR DESCRIPTION
#### O que esse PR faz?
Remove entrada !.env/.local para evitar inclusão de secrets em commits