### PR TITLE
[Silver Pipeline] - Parte 001 - Cria extratores e normalizadores de dados

### DIFF
--- a/etl/__init__.py
+++ b/etl/__init__.py
@@ -1,0 +1,1 @@
+"""ETL helpers for OCA data pipelines."""

--- a/etl/extractors.py
+++ b/etl/extractors.py
@@ -2,6 +2,20 @@ from typing import Any
 
 from etl.normalizers import normalize_text, stz_doi, stz_isbn, stz_issn
 
+__all__ = [
+    "display_name",
+    "extract_doi",
+    "extract_isbns",
+    "extract_issns",
+    "extract_scielo_id",
+    "extract_source",
+    "first_value",
+    "get_normalized_titles",
+    "match_key",
+    "normalize_identifiers",
+    "rebuild_abstract_from_inverted_index",
+]
+
 
 def extract_doi(doc: dict[str, Any]) -> str | None:
     if doi := doc.get("doi"):

--- a/etl/extractors.py
+++ b/etl/extractors.py
@@ -2,20 +2,6 @@ from typing import Any
 
 from etl.normalizers import normalize_text, stz_doi, stz_isbn, stz_issn
 
-__all__ = [
-    "display_name",
-    "extract_doi",
-    "extract_isbns",
-    "extract_issns",
-    "extract_scielo_id",
-    "extract_source",
-    "first_value",
-    "get_normalized_titles",
-    "match_key",
-    "normalize_identifiers",
-    "rebuild_abstract_from_inverted_index",
-]
-
 
 def extract_doi(doc: dict[str, Any]) -> str | None:
     if doi := doc.get("doi"):

--- a/etl/extractors.py
+++ b/etl/extractors.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from etl.normalizers import stz_doi, stz_isbn, stz_issn
+from etl.normalizers import normalize_text, stz_doi, stz_isbn, stz_issn
 
 
 def extract_doi(doc: dict[str, Any]) -> str | None:
@@ -158,3 +158,69 @@ def normalize_identifiers(raw_doc: dict[str, Any]) -> dict[str, str | None]:
             identifiers[key] = str(value).strip()
 
     return identifiers
+
+
+def extract_source(doc: dict[str, Any]) -> dict[str, Any]:
+    source = doc.get("source")
+    if isinstance(source, dict) and source:
+        return source
+
+    for location_key in ("primary_location", "best_oa_location"):
+        location = doc.get(location_key)
+        if isinstance(location, dict):
+            location_source = location.get("source")
+            if isinstance(location_source, dict):
+                return location_source
+
+    return {}
+
+
+def get_normalized_titles(doc: dict[str, Any]) -> list[str]:
+    titles: list[str] = []
+
+    for entry in doc.get("title_with_lang", []):
+        if isinstance(entry, dict) and entry.get("title"):
+            normalized = normalize_text(entry["title"])
+            if normalized:
+                titles.append(normalized.lower().strip())
+
+    if not titles:
+        title = doc.get("title") or doc.get("display_name", "")
+        if title:
+            normalized = normalize_text(title)
+            if normalized:
+                titles.append(normalized.lower().strip())
+
+    return titles
+
+
+def rebuild_abstract_from_inverted_index(inverted_index: dict) -> str | None:
+    if not inverted_index or not isinstance(inverted_index, dict):
+        return None
+
+    word_positions = []
+    for word, positions in inverted_index.items():
+        for position in positions:
+            word_positions.append((position, word))
+    word_positions.sort()
+    abstract = " ".join(word for _position, word in word_positions)
+    return normalize_text(abstract)
+
+
+def display_name(value: Any) -> Any:
+    if isinstance(value, dict):
+        return value.get("display_name") or value.get("name")
+    return value
+
+
+def first_value(value: Any) -> Any:
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, str) and "scielo.br" in item:
+                return item
+        return value[0] if value else None
+    return value
+
+
+def match_key(value: Any) -> str:
+    return " ".join(str(value or "").lower().split())

--- a/etl/extractors.py
+++ b/etl/extractors.py
@@ -1,0 +1,160 @@
+from typing import Any
+
+from etl.normalizers import stz_doi, stz_isbn, stz_issn
+
+
+def extract_doi(doc: dict[str, Any]) -> str | None:
+    if doi := doc.get("doi"):
+        return doi
+
+    ids = doc.get("ids") if isinstance(doc.get("ids"), dict) else {}
+    if ids.get("doi"):
+        return ids["doi"]
+
+    for items in (ids.get("doi_with_lang"), doc.get("doi_with_lang")):
+        for item in items or []:
+            if isinstance(item, dict):
+                return item.get("doi") or item.get("id") or item.get("value")
+            if item:
+                return item
+
+    return None
+
+
+def extract_isbns(doc: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    ids = doc.get("ids") if isinstance(doc.get("ids"), dict) else {}
+    biblio = doc.get("biblio") if isinstance(doc.get("biblio"), dict) else {}
+
+    for key in ("isbn", "eisbn", "isbns", "eisbns"):
+        raw_value = doc.get(key) or ids.get(key) or biblio.get(key)
+        if isinstance(raw_value, list):
+            values.extend(raw_value)
+        elif raw_value:
+            values.append(raw_value)
+
+    parent = doc.get("parent_book") if isinstance(doc.get("parent_book"), dict) else {}
+    parent_ids = parent.get("ids") if isinstance(parent.get("ids"), dict) else {}
+    for key in ("isbn", "eisbn", "isbns", "eisbns"):
+        raw_value = parent_ids.get(key)
+        if isinstance(raw_value, list):
+            values.extend(raw_value)
+        elif raw_value:
+            values.append(raw_value)
+
+    for location_key in ("primary_location", "best_oa_location"):
+        location = doc.get(location_key) if isinstance(doc.get(location_key), dict) else {}
+        source = location.get("source") if isinstance(location.get("source"), dict) else {}
+        raw_value = source.get("issns") or source.get("issn")
+        if isinstance(raw_value, list):
+            values.extend(raw_value)
+        elif raw_value:
+            values.append(raw_value)
+
+    for location in doc.get("locations") or []:
+        if not isinstance(location, dict):
+            continue
+        source = location.get("source") if isinstance(location.get("source"), dict) else {}
+        raw_value = source.get("issns") or source.get("issn")
+        if isinstance(raw_value, list):
+            values.extend(raw_value)
+        elif raw_value:
+            values.append(raw_value)
+
+    return sorted({normalized for value in values if (normalized := stz_isbn(value))})
+
+
+def extract_issns(doc: dict[str, Any]) -> list[str]:
+    issns: set[str] = set()
+
+    for field in ("source_issns", "journal_issns"):
+        raw_value = doc.get(field)
+        if isinstance(raw_value, list):
+            issns.update(raw_value)
+
+    source = doc.get("source")
+    if isinstance(source, dict):
+        for field in ("issns", "issn"):
+            raw_value = source.get(field)
+            if isinstance(raw_value, list):
+                issns.update(raw_value)
+            elif isinstance(raw_value, str):
+                issns.add(raw_value)
+
+    sources = doc.get("sources")
+    if isinstance(sources, list):
+        for source_item in sources:
+            if not isinstance(source_item, dict):
+                continue
+            for field in ("issn", "issns"):
+                raw_value = source_item.get(field)
+                if isinstance(raw_value, list):
+                    issns.update(raw_value)
+                elif isinstance(raw_value, str):
+                    issns.add(raw_value)
+
+    for location_key in ("primary_location", "best_oa_location"):
+        location = doc.get(location_key)
+        if not isinstance(location, dict):
+            continue
+        source_item = location.get("source")
+        if not isinstance(source_item, dict):
+            continue
+        for field in ("issns", "issn"):
+            raw_value = source_item.get(field)
+            if isinstance(raw_value, list):
+                issns.update(raw_value)
+            elif isinstance(raw_value, str):
+                issns.add(raw_value)
+
+    return sorted({normalized for value in issns if (normalized := stz_issn(value))})
+
+
+def extract_scielo_id(doc: dict[str, Any]) -> str | None:
+    if scielo_id := doc.get("scielo_id"):
+        return scielo_id
+    if pid_v2 := doc.get("pid_v2"):
+        return pid_v2
+    if code := doc.get("code"):
+        return code
+
+    ids = doc.get("ids") if isinstance(doc.get("ids"), dict) else {}
+    return ids.get("scl_preprint_id")
+
+
+def normalize_identifiers(raw_doc: dict[str, Any]) -> dict[str, str | None]:
+    identifiers: dict[str, str | None] = {}
+
+    if doi := extract_doi(raw_doc):
+        if normalized_doi := stz_doi(doi):
+            identifiers["doi"] = normalized_doi
+
+    ids = raw_doc.get("ids") if isinstance(raw_doc.get("ids"), dict) else {}
+
+    if issn := raw_doc.get("issn") or ids.get("issn"):
+        issn_values = issn if isinstance(issn, list) else [issn]
+        if normalized_issn := next(
+            (stz_issn(value) for value in issn_values if stz_issn(value)),
+            None,
+        ):
+            identifiers["issn"] = normalized_issn
+
+    if isbn := raw_doc.get("isbn") or ids.get("isbn") or ids.get("eisbn"):
+        isbn_values = isbn if isinstance(isbn, list) else [isbn]
+        if normalized_isbn := next(
+            (stz_isbn(value) for value in isbn_values if stz_isbn(value)),
+            None,
+        ):
+            identifiers["isbn"] = normalized_isbn
+
+    if openalex_id := raw_doc.get("openalex_id") or raw_doc.get("id"):
+        identifiers["openalex_id"] = str(openalex_id).strip()
+
+    if pid := raw_doc.get("pid_v2") or raw_doc.get("scielo_id"):
+        identifiers["scielo_id"] = str(pid).strip()
+
+    for key in ("pmid", "pmcid", "mag"):
+        if value := raw_doc.get(key):
+            identifiers[key] = str(value).strip()
+
+    return identifiers

--- a/etl/normalizers.py
+++ b/etl/normalizers.py
@@ -133,3 +133,36 @@ def stz_language(language: str | None) -> str | None:
                 return language_item.alpha_2
 
     return None
+
+
+def stz_country_code(country: str | None) -> str | None:
+    if not country:
+        return None
+
+    country_value = str(country).strip()
+
+    if len(country_value) == 2 and country_value.isalpha():
+        result = pycountry.countries.get(alpha_2=country_value.upper())
+        if result:
+            return result.alpha_2
+
+    if len(country_value) == 3 and country_value.isalpha():
+        result = pycountry.countries.get(alpha_3=country_value.upper())
+        if result:
+            return result.alpha_2
+
+    try:
+        result = pycountry.countries.search_fuzzy(country_value)
+        if result:
+            return result[0].alpha_2
+    except (LookupError, ValueError):
+        pass
+
+    try:
+        result = pycountry.countries.lookup(country_value)
+        if result:
+            return result.alpha_2
+    except (LookupError, KeyError):
+        pass
+
+    return None

--- a/etl/normalizers.py
+++ b/etl/normalizers.py
@@ -1,4 +1,6 @@
 import re
+import unicodedata
+from typing import Any
 
 
 def stz_doi(doi: str | None) -> str | None:
@@ -34,3 +36,63 @@ def stz_issn(issn: str | None) -> str | None:
     if len(normalized) == 8:
         return f"{normalized[:4]}-{normalized[4:]}"
     return None
+
+
+def normalize_text(text: str | None) -> str | None:
+    if not text:
+        return None
+
+    normalized = str(text).strip()
+    nfkd = unicodedata.normalize("NFKD", normalized)
+    normalized = "".join(char for char in nfkd if not unicodedata.combining(char))
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized if normalized else None
+
+
+def normalize_name(name: str | None) -> str:
+    if not name:
+        return ""
+
+    normalized = str(name).lower().strip()
+    normalized = (
+        normalized.replace("\u2010", "-")
+        .replace("\u2013", "-")
+        .replace("\u2014", "-")
+    )
+    normalized = " ".join(normalized.split())
+    normalized = unicodedata.normalize("NFKD", normalized)
+    return "".join(char for char in normalized if not unicodedata.combining(char))
+
+
+def normalize_keywords(keywords: list[str] | None) -> list[str]:
+    if not keywords:
+        return []
+
+    normalized = {
+        normalized_keyword.lower()
+        for keyword in keywords
+        if (normalized_keyword := normalize_text(keyword))
+    }
+    return sorted(normalized)
+
+
+def int_or_none(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def as_list(value: Any) -> list:
+    if value in (None, [], {}):
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def unique(values: list) -> list:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def scalar_or_list(values: list):
+    values = unique(values)
+    return values[0] if len(values) == 1 else values

--- a/etl/normalizers.py
+++ b/etl/normalizers.py
@@ -4,6 +4,21 @@ from typing import Any
 
 import pycountry
 
+__all__ = [
+    "as_list",
+    "int_or_none",
+    "normalize_keywords",
+    "normalize_name",
+    "normalize_text",
+    "scalar_or_list",
+    "stz_country_code",
+    "stz_doi",
+    "stz_isbn",
+    "stz_issn",
+    "stz_language",
+    "unique",
+]
+
 
 def stz_doi(doi: str | None) -> str | None:
     if not doi:

--- a/etl/normalizers.py
+++ b/etl/normalizers.py
@@ -1,0 +1,36 @@
+import re
+
+
+def stz_doi(doi: str | None) -> str | None:
+    if not doi:
+        return None
+
+    normalized = str(doi).strip().lower()
+    normalized = re.sub(r"^https?://(dx\.)?doi\.org/", "", normalized)
+    normalized = re.sub(r"^doi:", "", normalized)
+    normalized = re.sub(r"([0-9\-])([a-z]{2})$", r"\1", normalized)
+
+    return normalized if re.match(r"^10\.\d{4,9}/\S+$", normalized) else None
+
+
+def stz_isbn(isbn: str | None) -> str | None:
+    if not isbn:
+        return None
+
+    normalized = str(isbn).strip().replace("-", "").replace(" ", "")
+    if len(normalized) == 10 and re.match(r"^\d{9}[\dX]$", normalized, re.IGNORECASE):
+        return normalized.upper()
+    if len(normalized) == 13 and normalized.isdigit():
+        return normalized
+
+    return None
+
+
+def stz_issn(issn: str | None) -> str | None:
+    if not issn:
+        return None
+
+    normalized = re.sub(r"[^\dX]", "", str(issn).upper())
+    if len(normalized) == 8:
+        return f"{normalized[:4]}-{normalized[4:]}"
+    return None

--- a/etl/normalizers.py
+++ b/etl/normalizers.py
@@ -2,6 +2,8 @@ import re
 import unicodedata
 from typing import Any
 
+import pycountry
+
 
 def stz_doi(doi: str | None) -> str | None:
     if not doi:
@@ -96,3 +98,38 @@ def unique(values: list) -> list:
 def scalar_or_list(values: list):
     values = unique(values)
     return values[0] if len(values) == 1 else values
+
+
+def stz_language(language: str | None) -> str | None:
+    if not language:
+        return None
+
+    language_value = str(language).strip()
+
+    if len(language_value) == 2 and language_value.isalpha():
+        result = pycountry.languages.get(alpha_2=language_value.lower())
+        if result:
+            return result.alpha_2
+
+    if len(language_value) == 3 and language_value.isalpha():
+        result = pycountry.languages.get(alpha_3=language_value.lower())
+        if result and hasattr(result, "alpha_2"):
+            return result.alpha_2
+
+        result = pycountry.languages.get(bibliographic=language_value.lower())
+        if result and hasattr(result, "alpha_2"):
+            return result.alpha_2
+
+    language_lower = language_value.lower()
+    for language_item in pycountry.languages:
+        if hasattr(language_item, "name") and language_item.name.lower() == language_lower:
+            if hasattr(language_item, "alpha_2"):
+                return language_item.alpha_2
+        if (
+            hasattr(language_item, "common_name")
+            and language_item.common_name.lower() == language_lower
+        ):
+            if hasattr(language_item, "alpha_2"):
+                return language_item.alpha_2
+
+    return None

--- a/etl/normalizers.py
+++ b/etl/normalizers.py
@@ -4,21 +4,6 @@ from typing import Any
 
 import pycountry
 
-__all__ = [
-    "as_list",
-    "int_or_none",
-    "normalize_keywords",
-    "normalize_name",
-    "normalize_text",
-    "scalar_or_list",
-    "stz_country_code",
-    "stz_doi",
-    "stz_isbn",
-    "stz_issn",
-    "stz_language",
-    "unique",
-]
-
 
 def stz_doi(doi: str | None) -> str | None:
     if not doi:

--- a/etl/tests/__init__.py
+++ b/etl/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ETL helper modules."""

--- a/etl/tests/test_extractors.py
+++ b/etl/tests/test_extractors.py
@@ -1,0 +1,64 @@
+from django.test import SimpleTestCase
+
+from etl.extractors import (
+    extract_doi,
+    extract_isbns,
+    extract_issns,
+    extract_scielo_id,
+    normalize_identifiers,
+)
+
+
+class IdentifierExtractorTests(SimpleTestCase):
+    def test_extract_doi_reads_top_level_ids_and_language_items(self):
+        self.assertEqual(extract_doi({"doi": "10.1590/a"}), "10.1590/a")
+        self.assertEqual(extract_doi({"ids": {"doi": "10.1590/b"}}), "10.1590/b")
+        self.assertEqual(
+            extract_doi({"doi_with_lang": [{"language": "pt", "doi": "10.1590/c"}]}),
+            "10.1590/c",
+        )
+
+    def test_extract_isbns_reads_document_parent_and_location_values(self):
+        doc = {
+            "isbn": "978-65-00-00000-1",
+            "parent_book": {"ids": {"isbn": "85-359-0277-5"}},
+            "primary_location": {"source": {"issns": ["9788500000002"]}},
+        }
+
+        self.assertEqual(
+            extract_isbns(doc),
+            ["8535902775", "9786500000001", "9788500000002"],
+        )
+
+    def test_extract_issns_normalizes_source_values(self):
+        doc = {
+            "source_issns": ["0102-311X"],
+            "source": {"issn": "0034-8910"},
+            "primary_location": {"source": {"issns": ["1415-790X"]}},
+        }
+
+        self.assertEqual(extract_issns(doc), ["0034-8910", "0102-311X", "1415-790X"])
+
+    def test_extract_scielo_id_prefers_explicit_values(self):
+        self.assertEqual(extract_scielo_id({"scielo_id": "S1"}), "S1")
+        self.assertEqual(extract_scielo_id({"pid_v2": "S2"}), "S2")
+        self.assertEqual(extract_scielo_id({"ids": {"scl_preprint_id": "P1"}}), "P1")
+
+    def test_normalize_identifiers_builds_indexed_identifier_shape(self):
+        identifiers = normalize_identifiers(
+            {
+                "doi": "https://doi.org/10.1590/S0102-311X2024000100001",
+                "issn": ["bad", "0102-311X"],
+                "isbn": "978-65-00-00000-1",
+                "openalex_id": "https://openalex.org/W1",
+                "pid_v2": "S1",
+                "pmid": 123,
+            }
+        )
+
+        self.assertEqual(identifiers["doi"], "10.1590/s0102-311x2024000100001")
+        self.assertEqual(identifiers["issn"], "0102-311X")
+        self.assertEqual(identifiers["isbn"], "9786500000001")
+        self.assertEqual(identifiers["openalex_id"], "https://openalex.org/W1")
+        self.assertEqual(identifiers["scielo_id"], "S1")
+        self.assertEqual(identifiers["pmid"], "123")

--- a/etl/tests/test_extractors.py
+++ b/etl/tests/test_extractors.py
@@ -1,11 +1,17 @@
 from django.test import SimpleTestCase
 
 from etl.extractors import (
+    display_name,
     extract_doi,
     extract_isbns,
     extract_issns,
     extract_scielo_id,
+    extract_source,
+    first_value,
+    get_normalized_titles,
+    match_key,
     normalize_identifiers,
+    rebuild_abstract_from_inverted_index,
 )
 
 
@@ -62,3 +68,53 @@ class IdentifierExtractorTests(SimpleTestCase):
         self.assertEqual(identifiers["openalex_id"], "https://openalex.org/W1")
         self.assertEqual(identifiers["scielo_id"], "S1")
         self.assertEqual(identifiers["pmid"], "123")
+
+
+class SourceAndTextExtractorTests(SimpleTestCase):
+    def test_extract_source_prefers_top_level_source(self):
+        self.assertEqual(
+            extract_source({"source": {"title": "Journal"}}),
+            {"title": "Journal"},
+        )
+
+    def test_extract_source_falls_back_to_location_source(self):
+        self.assertEqual(
+            extract_source({"primary_location": {"source": {"title": "Book"}}}),
+            {"title": "Book"},
+        )
+
+    def test_get_normalized_titles_reads_multilingual_titles_first(self):
+        titles = get_normalized_titles(
+            {
+                "title": "Fallback title",
+                "title_with_lang": [{"language": "pt", "title": "T\u00edtulo"}],
+            }
+        )
+
+        self.assertEqual(titles, ["titulo"])
+
+    def test_get_normalized_titles_falls_back_to_display_name(self):
+        self.assertEqual(
+            get_normalized_titles({"display_name": "OpenAlex title"}),
+            ["openalex title"],
+        )
+
+    def test_rebuild_abstract_from_inverted_index_orders_tokens(self):
+        abstract = rebuild_abstract_from_inverted_index(
+            {"world": [1], "Hello": [0], "again": [2]}
+        )
+
+        self.assertEqual(abstract, "Hello world again")
+
+    def test_display_name_reads_common_name_fields(self):
+        self.assertEqual(display_name({"display_name": "Name"}), "Name")
+        self.assertEqual(display_name("raw"), "raw")
+
+    def test_first_value_prefers_scielo_url(self):
+        self.assertEqual(
+            first_value(["https://example.org/file.pdf", "https://scielo.br/article"]),
+            "https://scielo.br/article",
+        )
+
+    def test_match_key_normalizes_case_and_whitespace(self):
+        self.assertEqual(match_key("  Mixed   Case  "), "mixed case")

--- a/etl/tests/test_normalizers.py
+++ b/etl/tests/test_normalizers.py
@@ -1,0 +1,31 @@
+from django.test import SimpleTestCase
+
+from etl.normalizers import stz_doi, stz_isbn, stz_issn
+
+
+class IdentifierNormalizerTests(SimpleTestCase):
+    def test_stz_doi_strips_url_prefix_and_lowercases(self):
+        self.assertEqual(
+            stz_doi("https://doi.org/10.1590/S0102-311X2024000100001"),
+            "10.1590/s0102-311x2024000100001",
+        )
+
+    def test_stz_doi_rejects_invalid_values(self):
+        self.assertIsNone(stz_doi("not-a-doi"))
+        self.assertIsNone(stz_doi(None))
+
+    def test_stz_isbn_accepts_isbn10_and_isbn13(self):
+        self.assertEqual(stz_isbn("85-359-0277-5"), "8535902775")
+        self.assertEqual(stz_isbn("978 65 0000000 1"), "9786500000001")
+
+    def test_stz_isbn_rejects_invalid_values(self):
+        self.assertIsNone(stz_isbn("123"))
+        self.assertIsNone(stz_isbn(None))
+
+    def test_stz_issn_formats_eight_digits(self):
+        self.assertEqual(stz_issn("0102-311X"), "0102-311X")
+        self.assertEqual(stz_issn("0102311X"), "0102-311X")
+
+    def test_stz_issn_rejects_invalid_values(self):
+        self.assertIsNone(stz_issn("123"))
+        self.assertIsNone(stz_issn(None))

--- a/etl/tests/test_normalizers.py
+++ b/etl/tests/test_normalizers.py
@@ -1,6 +1,17 @@
 from django.test import SimpleTestCase
 
-from etl.normalizers import stz_doi, stz_isbn, stz_issn
+from etl.normalizers import (
+    as_list,
+    int_or_none,
+    normalize_keywords,
+    normalize_name,
+    normalize_text,
+    scalar_or_list,
+    stz_doi,
+    stz_isbn,
+    stz_issn,
+    unique,
+)
 
 
 class IdentifierNormalizerTests(SimpleTestCase):
@@ -29,3 +40,34 @@ class IdentifierNormalizerTests(SimpleTestCase):
     def test_stz_issn_rejects_invalid_values(self):
         self.assertIsNone(stz_issn("123"))
         self.assertIsNone(stz_issn(None))
+
+
+class TextAndCollectionNormalizerTests(SimpleTestCase):
+    def test_normalize_text_collapses_spaces_and_strips_accents(self):
+        self.assertEqual(normalize_text("  Sa\u00fade   p\u00fablica  "), "Saude publica")
+        self.assertIsNone(normalize_text(""))
+
+    def test_normalize_name_is_case_and_dash_insensitive(self):
+        self.assertEqual(normalize_name(" Jo\u00e3o\u2013Silva  "), "joao-silva")
+        self.assertEqual(normalize_name(None), "")
+
+    def test_normalize_keywords_deduplicates_and_sorts(self):
+        self.assertEqual(
+            normalize_keywords(["Sa\u00fade", "saude", "Epidemiologia"]),
+            ["epidemiologia", "saude"],
+        )
+
+    def test_int_or_none_converts_safe_values(self):
+        self.assertEqual(int_or_none("2024"), 2024)
+        self.assertIsNone(int_or_none("not-a-year"))
+
+    def test_as_list_wraps_scalar_values(self):
+        self.assertEqual(as_list("abc"), ["abc"])
+        self.assertEqual(as_list([]), [])
+
+    def test_unique_keeps_first_occurrence_order(self):
+        self.assertEqual(unique(["b", "a", "b", None]), ["b", "a"])
+
+    def test_scalar_or_list_returns_scalar_for_single_value(self):
+        self.assertEqual(scalar_or_list(["a", "a"]), "a")
+        self.assertEqual(scalar_or_list(["a", "b"]), ["a", "b"])

--- a/etl/tests/test_normalizers.py
+++ b/etl/tests/test_normalizers.py
@@ -10,6 +10,7 @@ from etl.normalizers import (
     stz_doi,
     stz_isbn,
     stz_issn,
+    stz_language,
     unique,
 )
 
@@ -71,3 +72,17 @@ class TextAndCollectionNormalizerTests(SimpleTestCase):
     def test_scalar_or_list_returns_scalar_for_single_value(self):
         self.assertEqual(scalar_or_list(["a", "a"]), "a")
         self.assertEqual(scalar_or_list(["a", "b"]), ["a", "b"])
+
+
+class LanguageNormalizerTests(SimpleTestCase):
+    def test_stz_language_accepts_iso_639_codes(self):
+        self.assertEqual(stz_language("pt"), "pt")
+        self.assertEqual(stz_language("por"), "pt")
+        self.assertEqual(stz_language("eng"), "en")
+
+    def test_stz_language_accepts_language_names(self):
+        self.assertEqual(stz_language("Portuguese"), "pt")
+
+    def test_stz_language_rejects_unknown_values(self):
+        self.assertIsNone(stz_language("not-a-language"))
+        self.assertIsNone(stz_language(None))

--- a/etl/tests/test_normalizers.py
+++ b/etl/tests/test_normalizers.py
@@ -7,6 +7,7 @@ from etl.normalizers import (
     normalize_name,
     normalize_text,
     scalar_or_list,
+    stz_country_code,
     stz_doi,
     stz_isbn,
     stz_issn,
@@ -86,3 +87,16 @@ class LanguageNormalizerTests(SimpleTestCase):
     def test_stz_language_rejects_unknown_values(self):
         self.assertIsNone(stz_language("not-a-language"))
         self.assertIsNone(stz_language(None))
+
+
+class CountryNormalizerTests(SimpleTestCase):
+    def test_stz_country_code_accepts_alpha_codes(self):
+        self.assertEqual(stz_country_code("BR"), "BR")
+        self.assertEqual(stz_country_code("bra"), "BR")
+
+    def test_stz_country_code_accepts_country_names(self):
+        self.assertEqual(stz_country_code("Brazil"), "BR")
+
+    def test_stz_country_code_rejects_unknown_values(self):
+        self.assertIsNone(stz_country_code("not-a-country"))
+        self.assertIsNone(stz_country_code(None))


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a base técnica de helpers puros para o ETL: normalização de DOI, ISBN, ISSN, idioma, país, texto, listas e extração de identificadores/metadados comuns de payloads SciELO/OpenAlex.

#### Onde a revisão poderia começar?
`etl/normalizers.py` e depois `etl/extractors.py`.

#### Como este poderia ser testado manualmente?
Rodar:

```bash
docker compose -f local.yml run --rm django pytest etl/tests/test_normalizers.py etl/tests/test_extractors.py --create-db
```

#### Algum cenário de contexto que queira dar?
Este PR prepara a base para a geração do índice Silver, separando helpers puros antes da introdução de models, pipeline, OpenSearch, tasks e admin.

### Screenshots
N/A.

#### Quais são tickets relevantes?
Relacionado a #645.

### Referências
- https://github.com/scieloorg/scms-oca/issues/645