### PR TITLE
Fix: Busca padrão não buscava em todos os campos

### DIFF
--- a/search/choices.py
+++ b/search/choices.py
@@ -136,7 +136,6 @@ SEARCH_OPERATORS = [
 ]
 
 SEARCH_FIELD_MAPPING = {
-    "all": ["title_search", "ids_search"],
     "title_search": ["title_search"],
     "ids_search": ["ids_search"],
     "authors_search": ["authors_search"],

--- a/search_gateway/query.py
+++ b/search_gateway/query.py
@@ -219,7 +219,7 @@ def _build_advanced_query(query_text):
 
 def _build_clause_query(field_key, query_text):
     """Build a simple text clause for a given field without advanced syntax parsing."""
-    fields = SEARCH_FIELD_MAPPING.get(field_key, ["title_search", "ids_search"])
+    fields = SEARCH_FIELD_MAPPING.get(field_key, sum(SEARCH_FIELD_MAPPING.values(), []))
     return {
         "multi_match": {
             "query": query_text,
@@ -408,7 +408,7 @@ def build_bool_query_from_search_params(
                 {
                     "multi_match": {
                         "query": query_text,
-                        "fields": ["title_search", "ids_search"],
+                        "fields": sum(SEARCH_FIELD_MAPPING.values(), []),
                         "operator": "and",
                     },
                 }


### PR DESCRIPTION
#### O que esse PR faz?
Realiza Fix na busca padrão em que a busca não estava "olhando" para todos os _search do indice.

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
Realizar a busca: abel laerte packer em todos os campos

### Screenshots
<img width="1536" height="491" alt="image" src="https://github.com/user-attachments/assets/9ac5035c-8c55-4cb1-acbe-6d7e038a5425" />
<img width="1536" height="491" alt="image" src="https://github.com/user-attachments/assets/4eb41df5-def2-41c1-8d29-a57fcf3ee224" />


