### PR TITLE
Restringe construtor de índices lookups para não sobrescrever lookups existentes

### DIFF
--- a/search_gateway/lookup/base.py
+++ b/search_gateway/lookup/base.py
@@ -274,28 +274,34 @@ def build_lookup_indices(
     builders: dict[str, LookupBuilder] = {
         key: lookup_builders[key]() for key in config.selected_lookups
     }
+    index_names = _resolve_index_names(builders)
 
     if not client.ping():
         raise ConnectionError("Could not connect to OpenSearch.")
     if not client.indices.exists(index=config.source_index):
         raise ValueError(f"Source index or alias '{config.source_index}' does not exist.")
 
-    for lookup_key, builder in builders.items():
-        index_name = _index_name(lookup_key, builder)
-        _ensure_index(index_name, builder.mapping)
+    _validate_target_indices(index_names)
 
     processed_docs = _collect(builders)
     indexed_counts: dict[str, int] = {"_processed_docs": processed_docs}
 
+    _validate_target_indices(index_names)
+
     for lookup_key, builder in builders.items():
-        index_name = _index_name(lookup_key, builder)
+        client.indices.create(index=index_names[lookup_key], body=builder.mapping)
+
+    for lookup_key, builder in builders.items():
+        index_name = index_names[lookup_key]
         if progress:
             progress(
                 f"Collected {builder.count():,} values for lookup '{lookup_key}' "
                 f"from {processed_docs:,} documents."
             )
         indexed_counts[lookup_key] = _bulk_index(
-            index_name, builder.iter_actions(index_name)
+            index_name,
+            builder.iter_actions(index_name),
+            builder.count(),
         )
 
     return indexed_counts

--- a/search_gateway/lookup/base.py
+++ b/search_gateway/lookup/base.py
@@ -219,16 +219,56 @@ def build_lookup_indices(
 
         return processed
 
-    def _bulk_index(index_name, actions):
+    def _bulk_index(index_name, actions, expected_count):
         success = 0
-        for ok, _ in streaming_bulk(
-            client, actions, chunk_size=config.batch_size, max_retries=3, raise_on_error=True
+        errors = []
+        if progress:
+            progress(
+                f"Starting bulk indexing {expected_count:,} lookup documents "
+                f"in '{index_name}'..."
+            )
+
+        for ok, item in streaming_bulk(
+            client, actions, chunk_size=config.batch_size, max_retries=3, raise_on_error=False
         ):
             if ok:
                 success += 1
-                if progress and success % 10000 == 0:
+                if progress and success % 5000 == 0:
                     progress(f"Indexed {success:,} lookup documents in '{index_name}'...")
+            elif len(errors) < 5:
+                errors.append(item)
+
+        if errors:
+            raise ValueError(
+                f"Bulk indexing failed for '{index_name}' after indexing "
+                f"{success:,} of {expected_count:,} lookup documents. "
+                f"First errors: {errors}"
+            )
+
+        if progress:
+            progress(f"Finished indexing {success:,} documents in '{index_name}'.")
+
         client.indices.refresh(index=index_name)
+        count_response = client.count(index=index_name)
+        if hasattr(count_response, "get"):
+            indexed_total = count_response.get("count")
+        elif hasattr(count_response, "body") and hasattr(count_response.body, "get"):
+            indexed_total = count_response.body.get("count")
+        else:
+            indexed_total = None
+        if indexed_total != success:
+            raise ValueError(
+                f"Index '{index_name}' count mismatch after refresh: bulk reported "
+                f"{success:,} successful documents, but OpenSearch count returned "
+                f"{indexed_total!r}."
+            )
+        if expected_count != success:
+            raise ValueError(
+                f"Index '{index_name}' expected {expected_count:,} lookup documents, "
+                f"but bulk reported {success:,} successful documents."
+            )
+        if progress:
+            progress(f"Verified {indexed_total:,} documents in '{index_name}'.")
         return success
 
     builders: dict[str, LookupBuilder] = {

--- a/search_gateway/lookup/base.py
+++ b/search_gateway/lookup/base.py
@@ -167,12 +167,33 @@ def build_lookup_indices(
     progress=None,
 ) -> dict[str, int]:
 
-    def _index_name(lookup_key, builder):
-        return config.lookup_index_overrides.get(lookup_key, builder.default_index_name)
+    def _resolve_index_names(builders):
+        index_names = {
+            lookup_key: config.lookup_index_overrides.get(
+                lookup_key,
+                builder.default_index_name,
+            )
+            for lookup_key, builder in builders.items()
+        }
+        seen: dict[str, str] = {}
+        for lookup_key, index_name in index_names.items():
+            existing_lookup_key = seen.get(index_name)
+            if existing_lookup_key:
+                raise ValueError(
+                    f"Lookups '{existing_lookup_key}' and '{lookup_key}' target the same "
+                    f"index '{index_name}'. Please use different index names."
+                )
+            seen[index_name] = lookup_key
+        return index_names
 
-    def _ensure_index(index_name, mapping):
-        if not client.indices.exists(index=index_name):
-            client.indices.create(index=index_name, body=mapping)
+    def _validate_target_indices(index_names):
+        for lookup_key, index_name in index_names.items():
+            if client.indices.exists(index=index_name):
+                raise ValueError(
+                    f"Target lookup index '{index_name}' already exists for lookup "
+                    f"'{lookup_key}'. Use --lookup-index {lookup_key}=<new_index> "
+                    "or delete the existing index first."
+                )
 
     def _collect(builders):
         source_fields = sorted(

--- a/search_gateway/lookup/base.py
+++ b/search_gateway/lookup/base.py
@@ -100,22 +100,23 @@ class LookupBuilder:
     ) -> dict[str, Any] | None:
         value = clean_text(value)
         label = clean_text(label)
-        is_new_value = value not in self.entries
 
         if not value or not label:
             return None
+
+        is_new_value = value not in self.entries
         if max_items is not None and is_new_value and len(self.entries) >= max_items:
             return None
 
-        entry = self.entries.setdefault(
-            value,
-            {
+        if is_new_value:
+            entry = {
                 "value": value,
                 "label": label,
                 "normalized_value": normalize_text(label),
-                "label_search": normalize_text(label),
-            },
-        )
+            }
+            self.entries[value] = entry
+        else:
+            entry = self.entries[value]
 
         for key, extra_value in extra.items():
             if isinstance(extra_value, set):
@@ -143,7 +144,6 @@ class LookupBuilder:
                     "value": entry["value"],
                     "label": entry["label"],
                     "normalized_value": entry["normalized_value"],
-                    "label_search": entry["label_search"],
                     "size": self.counts[value],
                 },
             }

--- a/search_gateway/lookup/base.py
+++ b/search_gateway/lookup/base.py
@@ -201,6 +201,9 @@ def build_lookup_indices(
         )
         query = {"_source": source_fields, "query": {"match_all": {}}}
         processed = 0
+        if progress:
+            progress(f"Scanning source index '{config.source_index}'...")
+
         for hit in scan(client, index=config.source_index, query=query, size=config.batch_size):
             source = hit.get("_source", {})
             processed += 1
@@ -210,6 +213,10 @@ def build_lookup_indices(
                 progress(f"Processed {processed:,} source documents...")
             if config.max_docs is not None and processed >= config.max_docs:
                 break
+
+        if progress:
+            progress(f"Finished scanning {processed:,} documents.")
+
         return processed
 
     def _bulk_index(index_name, actions):

--- a/search_gateway/tests/lookup/test_lookup_builder.py
+++ b/search_gateway/tests/lookup/test_lookup_builder.py
@@ -8,6 +8,7 @@ from search_gateway.option_normalization import normalize_text
 class LookupBuilderNormalizationTests(SimpleTestCase):
     def test_lookup_builder_mapping_configuration(self):
         mapping = LookupBuilder.build_mapping()
+        properties = mapping["mappings"]["properties"]
         
         analyzer_config = mapping['settings']['analysis']['analyzer']
         multilingual_filter = analyzer_config['multilingual']['filter']
@@ -23,6 +24,8 @@ class LookupBuilderNormalizationTests(SimpleTestCase):
                          getattr(settings, 'SEARCH_GATEWAY_LOOKUP_NUMBER_OF_SHARDS', 5))
         self.assertEqual(mapping['settings']['index']['number_of_replicas'], 
                          getattr(settings, 'SEARCH_GATEWAY_LOOKUP_NUMBER_OF_REPLICAS', 0))
+        self.assertEqual(properties["label"]["copy_to"], "label_search")
+        self.assertEqual(properties["label_search"]["type"], "search_as_you_type")
 
     def test_normalized_values_preserve_accents_and_capitalization(self):
         test_cases = [
@@ -89,9 +92,9 @@ class LookupBuilderNormalizationTests(SimpleTestCase):
         for value, label in test_entries:
             result = builder.add_entry(value, label, set())
             if result:
-                # Verify that normalized_value and label_search are the same after normalization
-                self.assertEqual(result['normalized_value'], result['label_search'])
-                
                 # Verify that normalization preserves capitalization and accents
                 expected_normalized = normalize_text(label)
                 self.assertEqual(result['normalized_value'], expected_normalized)
+
+        action = list(builder.iter_actions("test_index"))[0]
+        self.assertNotIn("label_search", action["_source"])

--- a/search_gateway/tests/lookup/test_main_lookup.py
+++ b/search_gateway/tests/lookup/test_main_lookup.py
@@ -184,6 +184,134 @@ class BuildLookupCommandTests(SimpleTestCase):
         with self.assertRaisesMessage(ValueError, "Source index or alias 'scientific_production' does not exist"):
             build_lookup_indices(client, config, LOOKUP_BUILDERS)
 
+    def test_build_service_rejects_existing_target_index_before_creating_any_index(self):
+        client = Mock()
+        client.ping.return_value = True
+        client.indices.exists.side_effect = lambda index: index in {
+            "scientific_production",
+            "lookup_publisher",
+        }
+        config = BuildConfig(
+            source_index="scientific_production",
+            batch_size=100,
+            max_docs=None,
+            selected_lookups=["source", "publisher"],
+            lookup_index_overrides={},
+            max_items={},
+        )
+
+        with self.assertRaisesMessage(ValueError, "Target lookup index 'lookup_publisher' already exists"):
+            build_lookup_indices(client, config, LOOKUP_BUILDERS)
+
+        client.indices.create.assert_not_called()
+
+    def test_build_service_rejects_duplicate_target_index_names(self):
+        client = Mock()
+        config = BuildConfig(
+            source_index="scientific_production",
+            batch_size=100,
+            max_docs=None,
+            selected_lookups=["source", "publisher"],
+            lookup_index_overrides={"source": "lookup_shared", "publisher": "lookup_shared"},
+            max_items={},
+        )
+
+        with self.assertRaisesMessage(ValueError, "target the same index 'lookup_shared'"):
+            build_lookup_indices(client, config, LOOKUP_BUILDERS)
+
+        client.ping.assert_not_called()
+        client.indices.create.assert_not_called()
+
+    @patch("search_gateway.lookup.base.streaming_bulk")
+    @patch("search_gateway.lookup.base.scan")
+    def test_build_service_verifies_index_count_after_bulk(self, scan_mock, streaming_bulk_mock):
+        client = Mock()
+        client.ping.return_value = True
+        client.indices.exists.side_effect = lambda index: index == "scientific_production"
+        client.count.return_value = {"count": 1}
+        scan_mock.return_value = [
+            {
+                "_source": {
+                    "sources": [{"type": "journal"}],
+                    "publishers": [{"name": "SciELO"}],
+                }
+            }
+        ]
+        streaming_bulk_mock.return_value = [(True, {"index": {"_id": "SciELO"}})]
+        config = BuildConfig(
+            source_index="scientific_production",
+            batch_size=100,
+            max_docs=None,
+            selected_lookups=["publisher"],
+            lookup_index_overrides={},
+            max_items={},
+        )
+
+        counts = build_lookup_indices(client, config, LOOKUP_BUILDERS)
+
+        self.assertEqual(counts["publisher"], 1)
+        client.indices.refresh.assert_called_once_with(index="lookup_publisher")
+        client.count.assert_called_once_with(index="lookup_publisher")
+
+    @patch("search_gateway.lookup.base.streaming_bulk")
+    @patch("search_gateway.lookup.base.scan")
+    def test_build_service_raises_when_index_count_does_not_match_bulk(self, scan_mock, streaming_bulk_mock):
+        client = Mock()
+        client.ping.return_value = True
+        client.indices.exists.side_effect = lambda index: index == "scientific_production"
+        client.count.return_value = {"count": 0}
+        scan_mock.return_value = [
+            {
+                "_source": {
+                    "sources": [{"type": "journal"}],
+                    "publishers": [{"name": "SciELO"}],
+                }
+            }
+        ]
+        streaming_bulk_mock.return_value = [(True, {"index": {"_id": "SciELO"}})]
+        config = BuildConfig(
+            source_index="scientific_production",
+            batch_size=100,
+            max_docs=None,
+            selected_lookups=["publisher"],
+            lookup_index_overrides={},
+            max_items={},
+        )
+
+        with self.assertRaisesMessage(ValueError, "count mismatch after refresh"):
+            build_lookup_indices(client, config, LOOKUP_BUILDERS)
+
+    @patch("search_gateway.lookup.base.streaming_bulk")
+    @patch("search_gateway.lookup.base.scan")
+    def test_build_service_reports_bulk_errors(self, scan_mock, streaming_bulk_mock):
+        client = Mock()
+        client.ping.return_value = True
+        client.indices.exists.side_effect = lambda index: index == "scientific_production"
+        scan_mock.return_value = [
+            {
+                "_source": {
+                    "sources": [{"type": "journal"}],
+                    "publishers": [{"name": "SciELO"}],
+                }
+            }
+        ]
+        streaming_bulk_mock.return_value = [
+            (False, {"index": {"_id": "SciELO", "error": "mapping error"}})
+        ]
+        config = BuildConfig(
+            source_index="scientific_production",
+            batch_size=100,
+            max_docs=None,
+            selected_lookups=["publisher"],
+            lookup_index_overrides={},
+            max_items={},
+        )
+
+        with self.assertRaisesMessage(ValueError, "Bulk indexing failed for 'lookup_publisher'"):
+            build_lookup_indices(client, config, LOOKUP_BUILDERS)
+
+        client.count.assert_not_called()
+
     @patch("search_gateway.management.commands.build_lookup_indices.build_lookup_indices")
     @patch("search_gateway.management.commands.build_lookup_indices.get_opensearch_client")
     def test_command_validates_batch_size(self, get_client_mock, build_mock):


### PR DESCRIPTION
#### O que esse PR faz?
Faz com que o lookup não seja sobrescrito.

#### Onde a revisão poderia começar?
N/A

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A
