### PR TITLE
fix(nav): fecha submenu desktop ao sair com o mouse

### DIFF
--- a/core/static/js/custom.js
+++ b/core/static/js/custom.js
@@ -178,4 +178,18 @@ $('.lang-select').change(function(){
 
         closeAllMenus();
     });
+
+    const desktopNavMediaQuery = window.matchMedia('(min-width: 992px)');
+
+    $(document).on(
+        'mouseleave.analyticsMenuDesktop',
+        `${desktopRootSelector} .menu-item.sub-menu`,
+        function () {
+            if (!desktopNavMediaQuery.matches) {
+                return;
+            }
+
+            closeBranch($(this));
+        }
+    );
 })(jQuery);


### PR DESCRIPTION
#### O que esse PR faz?
Ao clicar em uma categória na subnav, o pop com os submenus ficavam fixados. Realiza um fix para mostrar os submenus apenas com o mouse em cima, mesmo clicando na categoria.


