### PR TITLE
Cria comando para povar indice openalex only (não mesclados)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -543,6 +543,10 @@ ETL_SILVER_INDEX_PATTERN = env.str("ETL_SILVER_INDEX_PATTERN", "silver_scientifi
 ETL_SILVER_WRITE_ALIAS = env.str("ETL_SILVER_WRITE_ALIAS", "silver_write")
 ETL_SILVER_ROLLOVER_MAX_SIZE = env.str("ETL_SILVER_ROLLOVER_MAX_SIZE", default="30gb")
 
+# ETL OpenAlex-only Backfill
+ETL_OPENALEX_ONLY_INDEX_PATTERN = env.str("ETL_OPENALEX_ONLY_INDEX_PATTERN", "silver_openalex")
+ETL_OPENALEX_ONLY_WRITE_ALIAS = env.str("ETL_OPENALEX_ONLY_WRITE_ALIAS", "silver_openalex_write")
+
 # OpenSearch Raw Index Names
 OS_INDEX_RAW_PREPRINT = env.str("OS_INDEX_RAW_PREPRINT", "raw_scielo_preprint")
 OS_INDEX_RAW_BOOK = env.str("OS_INDEX_RAW_BOOK", "raw_scielo_book")

--- a/etl/deduplicator/openalex.py
+++ b/etl/deduplicator/openalex.py
@@ -14,6 +14,7 @@ from etl.transform.extractors import (
     extract_isbns,
     extract_issns,
     extract_source,
+    extract_titles,
 )
 
 logger = logging.getLogger(__name__)
@@ -316,9 +317,12 @@ class OpenAlexMatcher:
             if validation_rules["require_source_match"]:
                 return False, "rejected", {"reasons": reasons, "score": confidence_score}
 
-        scl_title = normalize_text(scielo_doc.get("title", "") or "")
-        oa_title = normalize_text(openalex_doc.get("title", "") or "")
-        article_title_sim = calculate_similarity(scl_title, oa_title)
+        scl_titles = extract_titles(scielo_doc)
+        oa_titles = extract_titles(openalex_doc)
+        article_title_sim = max(
+            (calculate_similarity(scl_t, oa_t) for scl_t in scl_titles for oa_t in oa_titles),
+            default=0.0,
+        )
 
         if (
             isbn_intersection
@@ -337,7 +341,12 @@ class OpenAlexMatcher:
             reasons.append(f"article_title_match_{article_title_sim:.2f}")
         else:
             reasons.append(f"article_title_low_sim_{article_title_sim:.2f}")
-            if not doi_match and scl_title and oa_title and article_title_sim < validation_rules["title_reject_threshold"]:
+            if (
+                not doi_match
+                and scl_titles
+                and oa_titles
+                and article_title_sim < validation_rules["title_reject_threshold"]
+            ):
                 return (
                     False,
                     "low_confidence",

--- a/etl/deduplicator/openalex.py
+++ b/etl/deduplicator/openalex.py
@@ -58,7 +58,7 @@ class OpenAlexMatcher:
                 matches.extend(self._try_openalex_by_title(primary, max_candidates))
 
         matches = self._deduplicate_openalex_matches(matches)
-        logger.info("Found %s validated OpenAlex matches for SciELO group", len(matches))
+        logger.debug("Found %s validated OpenAlex matches for SciELO group", len(matches))
         return matches
 
     def _try_openalex_by_doi(self, primary: dict, max_candidates: int) -> list:

--- a/etl/deduplicator/openalex.py
+++ b/etl/deduplicator/openalex.py
@@ -68,12 +68,14 @@ class OpenAlexMatcher:
 
         matches = []
         for candidate in self._search_openalex_by_doi(doi_stz, primary)[:max_candidates]:
-            if normalize_doi(extract_doi(candidate)) != doi_stz:
+            candidate_doi = normalize_doi(extract_doi(candidate))
+            if candidate_doi != doi_stz:
                 continue
 
             is_valid, confidence, validation = self._validate_openalex_match(primary, candidate)
             if is_valid:
                 matches.append((candidate, "doi", confidence, validation))
+
         return matches
 
     def _try_openalex_by_isbn(self, primary: dict, max_candidates: int) -> list:
@@ -129,13 +131,13 @@ class OpenAlexMatcher:
             logger.warning("Invalid DOI after normalization: %s", doi)
             return []
 
-        query = {"bool": {"must": [{"match": {"doi": normalized_doi}}]}}
+        query = {"bool": {"filter": [{"wildcard": {"doi.keyword": f"*{normalized_doi}*"}}]}}
         if year is not None:
             try:
                 year = int(year)
-                query["bool"]["filter"] = [
+                query["bool"]["filter"].append(
                     {"range": {"publication_year": {"gte": year - 1, "lte": year + 1}}}
-                ]
+                )
             except (ValueError, TypeError):
                 pass
 

--- a/etl/deduplicator/scielo.py
+++ b/etl/deduplicator/scielo.py
@@ -48,7 +48,7 @@ class SciELODeduplicator:
         if len(articles) <= 1:
             return {0: articles} if articles else {}
 
-        logger.info("Starting SciELO deduplication for %s articles...", len(articles))
+        logger.debug("Starting SciELO deduplication for %s articles...", len(articles))
 
         uf = UnionFind(len(articles))
         doi_to_indices: Dict[str, List[int]] = defaultdict(list)
@@ -77,7 +77,7 @@ class SciELODeduplicator:
             components[uf.find(i)].append(articles[i])
 
         merged_count = sum(1 for group in components.values() if len(group) > 1)
-        logger.info(
+        logger.debug(
             "SciELO deduplication complete: %s articles -> %s groups (%s groups with duplicates)",
             len(articles),
             len(components),

--- a/etl/pipeline.py
+++ b/etl/pipeline.py
@@ -80,13 +80,6 @@ class OpenSearchETLPipeline:
         self.merger = SilverMerger()
         self.skipped_doc_ids = []
 
-        logger.info("OpenSearchETLPipeline initialized")
-        logger.info("  Input SciELO index: %s", self.input_scielo_index)
-        logger.info("  Input OpenAlex index: %s", self.input_openalex_index)
-        logger.info("  Silver index pattern: %s", self.silver_index_pattern)
-        logger.info("  Silver write alias: %s", self.silver_write_alias)
-        logger.info("  Batch size: %s", self.batch_size)
-
     def run(
         self,
         max_docs: Optional[int] = None,
@@ -115,27 +108,20 @@ class OpenSearchETLPipeline:
             "warnings": 0,
             "error_messages": [],
             "warning_messages": [],
+            "openalex_only_removed_after_merge": 0,
         }
 
-        logger.info("=" * 80)
-        logger.info("STARTING OPENSEARCH ETL PIPELINE")
-        logger.info("=" * 80)
-
         try:
-            logger.info("\n[Step 1] Loading input documents...")
             input_docs = self._load_scielo_input_documents(
                 max_docs=max_docs,
                 year_filter=year_filter,
                 doc_ids=doc_ids,
             )
             result["total_input_docs"] = len(input_docs)
-            logger.info(f"Loaded {len(input_docs)} input documents")
 
             if not input_docs:
-                logger.warning("No documents to process")
                 return self._finalize_result(result)
 
-            logger.info("\n[Step 2] Building SciELO document groups...")
             groups = self._build_scielo_groups(input_docs)
             result["total_groups_formed"] = len(groups)
             result["total_duplicates_found"] = sum(
@@ -156,20 +142,11 @@ class OpenSearchETLPipeline:
                             scielo_dedup_map[os_id] = [pid for pid in group_pids if pid]
             result["scielo_dedup_source_ids"] = scielo_dedup_source_ids
             result["scielo_dedup_map"] = scielo_dedup_map
-            logger.info(
-                f"Grouping complete: {len(input_docs)} docs -> "
-                f"{len(groups)} groups ({result['total_duplicates_found']} duplicates)"
-            )
 
-            logger.info("\n[Step 3] Processing document groups...")
             all_merged_docs = []
 
             for idx, (root_idx, group) in enumerate(groups.items(), 1):
                 try:
-                    logger.debug(
-                        f"Processing group {idx}/{len(groups)} ({len(group)} doc(s))"
-                    )
-
                     openalex_matches = self.openalex_matcher.find_matches(
                         scielo_group=group,
                         max_candidates=3,
@@ -196,11 +173,12 @@ class OpenSearchETLPipeline:
                             scielo_silver_docs.append(silver_doc)
 
                         except Exception as e:
-                            logger.warning(f"Error standardizing SciELO doc: {e}")
                             result["warning_messages"].append(f"Standardization error: {e}")
 
                     if not scielo_silver_docs:
-                        logger.warning(f"No standardized SciELO docs for group {idx}")
+                        result["warning_messages"].append(
+                            f"No standardized SciELO docs for group {idx}"
+                        )
                         continue
 
                     openalex_silver_matches = []
@@ -218,7 +196,6 @@ class OpenSearchETLPipeline:
                             )
 
                         except Exception as e:
-                            logger.warning(f"Error standardizing OpenAlex doc: {e}")
                             result["warning_messages"].append(
                                 f"OpenAlex standardization error: {e}"
                             )
@@ -232,21 +209,15 @@ class OpenSearchETLPipeline:
                     result["total_merged_docs"] += 1
 
                 except Exception as e:
-                    logger.error(f"Error processing group {idx}: {e}", exc_info=True)
                     result["error_messages"].append(f"Group {idx} processing error: {str(e)}")
 
-            logger.info("\n[Step 4] Indexing to silver indices...")
             indexed_count = self._index_silver_documents(all_merged_docs)
             result["total_indexed_docs"] = indexed_count
             result["total_skipped_docs"] = len(self.skipped_doc_ids)
             result["skipped_doc_ids"] = self.skipped_doc_ids
-            logger.info(f"Indexed {indexed_count} documents to silver indices")
-            if self.skipped_doc_ids:
-                logger.warning(f"Skipped {len(self.skipped_doc_ids)} documents due to missing publication_year")
 
-            logger.info("\n" + "=" * 80)
-            logger.info("PIPELINE EXECUTION COMPLETE")
-            logger.info("=" * 80)
+            removed_count = self._remove_openalex_only_placeholders(all_merged_docs)
+            result["openalex_only_removed_after_merge"] = removed_count
 
         except Exception as e:
             logger.error(f"Pipeline failed: {e}", exc_info=True)
@@ -327,7 +298,6 @@ class OpenSearchETLPipeline:
         if max_docs and len(docs) > max_docs:
             docs = docs[:max_docs]
 
-        logger.info(f"Loaded {len(docs)} documents")
         return docs
 
     def _finalize_result(self, result: dict) -> dict:
@@ -472,7 +442,6 @@ class OpenSearchETLPipeline:
         docs_to_index = []
         for doc in silver_docs:
             if not doc.publication_year:
-                logger.warning(f"Document missing publication_year: {doc.doc_id}")
                 self.skipped_doc_ids.append(doc.doc_id)
                 continue
             docs_to_index.append(doc)
@@ -541,15 +510,11 @@ class OpenSearchETLPipeline:
                 if item.get("index", {}).get("status", 200) >= 400
             ]
             error_count = len(error_items)
-            logger.error(f"Bulk indexing had {error_count} errors")
-            stats_errors = [item.get("error") for item in error_items]
-            for err in stats_errors[:5]:
-                logger.error(f"  Index error: {err}")
+            first_error = error_items[0].get("error") if error_items else None
             raise RuntimeError(
-                f"Bulk indexing failed for {error_count} documents in {target_name}"
+                f"Bulk indexing failed for {error_count} documents in {target_name}: "
+                f"{first_error}"
             )
-
-        logger.info(f"Successfully indexed {expected_count} documents")
 
     def _stable_fallback_doc_id(self, raw_data: Dict[str, Any]) -> str:
         source_payload = {

--- a/etl/pipeline.py
+++ b/etl/pipeline.py
@@ -16,6 +16,11 @@ from etl.deduplicator.openalex import OpenAlexMatcher
 from etl.deduplicator.scielo import SciELODeduplicator
 from etl.models import EtlPipelineConfig
 from etl.transform.merger import SilverMerger
+from etl.transform.normalizers import (
+    normalize_doi,
+    normalize_openalex_id,
+    normalize_text,
+)
 from etl.transform.standardizer import standardizer_for
 from harvest.utils import clean_source_payload
 
@@ -56,7 +61,11 @@ class OpenSearchETLPipeline:
         self.pipeline_config = pipeline_config or EtlPipelineConfig.objects.get_for_source(self.input_scielo_index)
         self.document_type = self.pipeline_config.default_document_type
         self.input_openalex_index = self.pipeline_config.openalex_index_for(input_openalex_index)
-        self.silver_index_pattern = getattr(settings, "ETL_SILVER_INDEX_PATTERN", "silver_scientific_production")
+        self.silver_index_pattern = getattr(
+            settings,
+            "ETL_SILVER_INDEX_PATTERN",
+            "silver_scientific_production",
+        )
         self.silver_write_alias = getattr(settings, "ETL_SILVER_WRITE_ALIAS", "silver_write")
         self.rules = self.pipeline_config.to_rules()
 
@@ -247,50 +256,22 @@ class OpenSearchETLPipeline:
             "size": page_size,
         }
 
-        logger.info(f"Loading documents from {self.input_scielo_index}...")
-        if year_filter:
-            logger.info(f"  Year filter: {year_filter}")
-        if max_docs:
-            logger.info(f"  Max docs: {max_docs}")
-
         self.loaded_source_ids = set()
-        response = self.client.client.search(
-            index=self.input_scielo_index,
-            body=search_body,
-            scroll="5m",
-        )
-
-        scroll_id = response.get("_scroll_id")
         docs = []
-        try:
-            while True:
-                hits = response["hits"]["hits"]
-                if not hits:
-                    break
+        for hit, normalized in self._scroll_hits(self.input_scielo_index, search_body):
+            if (
+                self.pipeline_config.document_type_for_payload(normalized)
+                != self.pipeline_config.default_document_type
+            ):
+                continue
+            docs.append(normalized)
+            self.loaded_source_ids.update(
+                self._source_identity_values(hit.get("_id"), normalized)
+            )
 
-                for hit in hits:
-                    normalized = clean_source_payload(hit["_source"])
-                    if (
-                        self.pipeline_config.document_type_for_payload(normalized)
-                        != self.pipeline_config.default_document_type
-                    ):
-                        continue
-                    normalized["_os_id"] = hit.get("_id")
-                    docs.append(normalized)
-                    self.loaded_source_ids.update(
-                        self._source_identity_values(hit.get("_id"), normalized)
-                    )
-
-                if max_docs and len(docs) >= max_docs:
-                    docs = docs[:max_docs]
-                    break
-
-                response = self.client.client.scroll(scroll_id=scroll_id, scroll="5m")
-                scroll_id = response.get("_scroll_id")
-
-        finally:
-            if scroll_id:
-                self.client.client.clear_scroll(scroll_id=scroll_id)
+            if max_docs and len(docs) >= max_docs:
+                docs = docs[:max_docs]
+                break
 
         if doc_ids and docs:
             docs = self._expand_scielo_input_context(docs)
@@ -321,7 +302,7 @@ class OpenSearchETLPipeline:
 
         return self.scielo_deduplicator.find_duplicates(articles=input_docs)
 
-    def _expand_scielo_input_context(self, docs: List[Dict[str, Any]]    ) -> List[Dict[str, Any]]:
+    def _expand_scielo_input_context(self, docs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         field_values: dict[str, list] = defaultdict(list)
 
         for doc in docs:
@@ -337,12 +318,16 @@ class OpenSearchETLPipeline:
                     field_values[f"ids.{identity_field}"].append(value)
 
                 monograph = doc.get("monograph") or {}
-                m_ids = monograph.get("ids") or monograph
+                m_ids = monograph.get("ids")
                 if isinstance(m_ids, dict):
                     m_value = m_ids.get(identity_field)
                     if m_value:
                         field_values[f"ids.{identity_field}"].append(m_value)
                         field_values[f"monograph.ids.{identity_field}"].append(m_value)
+                        field_values[f"monograph.{identity_field}"].append(m_value)
+                elif isinstance(monograph, dict):
+                    m_value = monograph.get(identity_field)
+                    if m_value:
                         field_values[f"monograph.{identity_field}"].append(m_value)
 
         should = [
@@ -353,41 +338,18 @@ class OpenSearchETLPipeline:
         if not should:
             return docs
 
-        logger.info(f"Expanding context for {len(docs)} documents...")
         search_body = {
             "query": {"bool": {"should": should, "minimum_should_match": 1}},
             "size": 1000,
         }
 
-        combined = {str(doc): doc for doc in docs}
+        combined = {json.dumps(doc, sort_keys=True, ensure_ascii=True): doc for doc in docs}
 
-        response = self.client.client.search(
-            index=self.input_scielo_index,
-            body=search_body,
-            scroll="5m",
-        )
-        scroll_id = response.get("_scroll_id")
-
-        try:
-            while True:
-                hits = response["hits"]["hits"]
-                if not hits:
-                    break
-
-                for hit in hits:
-                    normalized = clean_source_payload(hit["_source"])
-                    normalized["_os_id"] = hit.get("_id")
-                    self.loaded_source_ids.update(
-                        self._source_identity_values(hit.get("_id"), normalized)
-                    )
-                    combined[str(normalized)] = normalized
-
-                response = self.client.client.scroll(scroll_id=scroll_id, scroll="5m")
-                scroll_id = response.get("_scroll_id")
-
-        finally:
-            if scroll_id:
-                self.client.client.clear_scroll(scroll_id=scroll_id)
+        for hit, normalized in self._scroll_hits(self.input_scielo_index, search_body):
+            self.loaded_source_ids.update(
+                self._source_identity_values(hit.get("_id"), normalized)
+            )
+            combined[json.dumps(normalized, sort_keys=True, ensure_ascii=True)] = normalized
 
         return list(combined.values())
 
@@ -408,12 +370,33 @@ class OpenSearchETLPipeline:
             values.add(ids.get(identity_field))
 
         monograph = source.get("monograph") or {}
-        m_ids = monograph.get("ids") or monograph
+        m_ids = monograph.get("ids")
         if isinstance(m_ids, dict):
             for identity_field in ("scl_preprint_id", "dataset_id", "scl_book_id", "doi", "isbn"):
                 values.add(m_ids.get(identity_field))
+        if isinstance(monograph, dict):
+            for identity_field in ("scl_preprint_id", "dataset_id", "scl_book_id", "doi", "isbn"):
+                values.add(monograph.get(identity_field))
 
         return {str(value) for value in values if value not in (None, "")}
+
+    def _scroll_hits(self, index: str, body: dict, scroll: str = "5m"):
+        response = self.client.client.search(index=index, body=body, scroll=scroll)
+        scroll_id = response.get("_scroll_id")
+        try:
+            while True:
+                hits = response["hits"]["hits"]
+                if not hits:
+                    break
+                for hit in hits:
+                    normalized = clean_source_payload(hit["_source"])
+                    normalized["_os_id"] = hit.get("_id")
+                    yield hit, normalized
+                response = self.client.client.scroll(scroll_id=scroll_id, scroll=scroll)
+                scroll_id = response.get("_scroll_id")
+        finally:
+            if scroll_id:
+                self.client.client.clear_scroll(scroll_id=scroll_id)
 
     def _build_input_document(
         self,
@@ -421,8 +404,8 @@ class OpenSearchETLPipeline:
         source: str = "scielo",
     ):
         if source == "scielo":
-            input_cls = self.pipeline_config.input_document_class()
-            return input_cls.from_raw(
+            doc_cls = self.pipeline_config.input_document_class()
+            return doc_cls.from_raw(
                 raw_data,
                 doc_type_fn=self.pipeline_config.document_type_for_payload,
                 fallback_id_fn=self._stable_fallback_doc_id,
@@ -449,15 +432,154 @@ class OpenSearchETLPipeline:
         if not docs_to_index:
             return 0
 
-        return self._index_silver_documents_to_rollover_alias(docs_to_index)
+        index_docs = self._prepare_silver_index_documents(docs_to_index)
+        return self._write_silver_documents(index_docs)
 
-    def _index_silver_documents_to_rollover_alias(
+    def _prepare_silver_index_documents(
         self,
         docs_to_index: List[SilverDocument],
+    ) -> list[tuple[str, SilverDocument]]:
+        docs_by_id: dict[str, list[SilverDocument]] = defaultdict(list)
+        for doc in docs_to_index:
+            docs_by_id[doc.doc_id].append(doc)
+
+        index_docs: list[tuple[str, SilverDocument]] = []
+        for doc_id, docs in docs_by_id.items():
+            if len(docs) == 1:
+                index_docs.append((doc_id, docs[0]))
+                continue
+
+            if self._silver_docs_can_share_index_id(docs):
+                merged_doc = self._merge_compatible_silver_docs(docs)
+                index_docs.append((merged_doc.doc_id, merged_doc))
+                continue
+
+            ranked_docs = sorted(
+                enumerate(docs),
+                key=lambda item: (
+                    len(self._openalex_ids_from_silver_doc(item[1])),
+                    len(item[1].title_with_lang or []),
+                    1 if self._normalized_silver_doi(item[1]) else 0,
+                    -item[0],
+                ),
+                reverse=True,
+            )
+            ordered_docs = [doc for _idx, doc in ranked_docs]
+            logger.warning(
+                "Conflicting silver documents share doc_id %s; keeping one on the "
+                "canonical _id and assigning alternate _ids to %s document(s)",
+                doc_id,
+                len(ordered_docs) - 1,
+            )
+            index_docs.append((doc_id, ordered_docs[0]))
+            for doc in ordered_docs[1:]:
+                digest = hashlib.sha256(
+                    json.dumps(
+                        doc.to_index_dict(),
+                        sort_keys=True,
+                        ensure_ascii=True,
+                    ).encode("utf-8")
+                ).hexdigest()
+                index_docs.append((f"{doc.doc_id}__{digest[:12]}", doc))
+
+        return index_docs
+
+    def _silver_docs_can_share_index_id(
+        self,
+        docs: list[SilverDocument],
+    ) -> bool:
+        doc_dois = [self._normalized_silver_doi(doc) for doc in docs]
+        known_dois = {doi for doi in doc_dois if doi}
+
+        if len(known_dois) > 1:
+            return False
+        if len(known_dois) == 1 and all(doc_dois):
+            return True
+
+        title_sets = []
+        for doc in docs:
+            title_values = set()
+            if normalized := normalize_text(doc.title):
+                title_values.add(normalized.lower())
+
+            for item in doc.title_with_lang or []:
+                if not isinstance(item, dict):
+                    continue
+                title = item.get("title") or item.get("text")
+                if normalized := normalize_text(title):
+                    title_values.add(normalized.lower())
+
+            if title_values:
+                title_sets.append(title_values)
+
+        if len(title_sets) < 2:
+            return True
+
+        return bool(set.intersection(*title_sets))
+
+    def _normalized_silver_doi(self, doc: SilverDocument) -> str | None:
+        ids = doc.ids if isinstance(doc.ids, dict) else {}
+        raw_doi = doc.doi or ids.get("doi")
+        if isinstance(raw_doi, list):
+            raw_doi = raw_doi[0] if raw_doi else None
+        return normalize_doi(raw_doi)
+
+    def _merge_compatible_silver_docs(
+        self,
+        docs: list[SilverDocument],
+    ) -> SilverDocument:
+        merged = self.merger.merge(scielo_docs=docs, openalex_matches=[])
+        data = merged.to_dict()
+
+        openalex_ids = []
+        openalex_lang_items = []
+        openalex_match_details = []
+        for doc in docs:
+            indexed = doc.to_index_dict()
+            ids = indexed.get("ids") or {}
+            openalex_ids.extend(self._openalex_ids_from_silver_doc(doc))
+            openalex_lang_items.extend(ids.get("openalex_with_lang") or [])
+            trace = (indexed.get("oca_data") or {}).get("merge_trace") or {}
+            openalex_match_details.extend(trace.get("openalex_matches") or [])
+
+        openalex_ids = list(dict.fromkeys(openalex_ids))
+        if openalex_ids:
+            data.setdefault("ids", {})["openalex"] = openalex_ids
+            data["openalex_id"] = openalex_ids[0]
+            openalex = dict(data.setdefault("oca_data", {}).get("openalex") or {})
+            openalex["ids"] = openalex_ids
+            data["oca_data"]["openalex"] = openalex
+            data["oca_data"]["scope"] = list(
+                dict.fromkeys(
+                    (data["oca_data"].get("scope") or []) + ["scielo", "openalex"]
+                )
+            )
+
+        if openalex_lang_items:
+            keyed_items = {
+                (item.get("language"), item.get("openalex")): item
+                for item in openalex_lang_items
+                if isinstance(item, dict) and item.get("language") and item.get("openalex")
+            }
+            data.setdefault("ids", {})["openalex_with_lang"] = list(keyed_items.values())
+
+        if openalex_match_details:
+            trace = data.setdefault("oca_data", {}).setdefault("merge_trace", {})
+            keyed_matches = {
+                item.get("doc_id"): item
+                for item in openalex_match_details
+                if isinstance(item, dict) and item.get("doc_id")
+            }
+            trace["openalex_matches"] = list(keyed_matches.values())
+
+        return SilverDocument(**data)
+
+    def _write_silver_documents(
+        self,
+        docs_to_index: list[tuple[str, SilverDocument]],
     ) -> int:
         index_prefix = self.silver_index_pattern
         write_alias = self.silver_write_alias
-        logger.info(f"Indexing {len(docs_to_index)} documents to {write_alias}...")
         bootstrap_index = self.client.ensure_rollover_index(
             index_prefix=index_prefix,
             write_alias=write_alias,
@@ -466,41 +588,34 @@ class OpenSearchETLPipeline:
         )
 
         actions = []
-        for doc in docs_to_index:
+        for index_id, doc in docs_to_index:
             actions.append(
                 {
                     "index": {
                         "_index": write_alias,
-                        "_id": doc.doc_id,
+                        "_id": index_id,
                     }
                 }
             )
             actions.append(doc.to_index_dict())
 
-        try:
-            self._bulk_index(actions, len(docs_to_index), write_alias)
-            if bootstrap_index:
-                self.indexed_index_names.add(bootstrap_index)
+        self._execute_bulk_index(actions, write_alias)
+        if bootstrap_index:
+            self.indexed_index_names.add(bootstrap_index)
 
-            rollover_index = self.client.rollover(
-                write_alias=write_alias,
-                public_alias=self.public_alias,
-                max_size=getattr(settings, "ETL_SILVER_ROLLOVER_MAX_SIZE", None),
-            )
-            if rollover_index:
-                self.indexed_index_names.add(rollover_index)
-            if not self.indexed_index_names:
-                self.indexed_index_names.add(write_alias)
-
-        except RuntimeError:
-            raise
-        except Exception as e:
-            logger.error(f"Failed to index to {write_alias}: {e}")
-            raise
+        rollover_index = self.client.rollover(
+            write_alias=write_alias,
+            public_alias=self.public_alias,
+            max_size=getattr(settings, "ETL_SILVER_ROLLOVER_MAX_SIZE", None),
+        )
+        if rollover_index:
+            self.indexed_index_names.add(rollover_index)
+        if not self.indexed_index_names:
+            self.indexed_index_names.add(write_alias)
 
         return len(docs_to_index)
 
-    def _bulk_index(self, actions: list[dict], expected_count: int, target_name: str) -> None:
+    def _execute_bulk_index(self, actions: list[dict], target_name: str) -> None:
         response = self.client.client.bulk(body=actions)
 
         if response.get("errors"):
@@ -527,3 +642,73 @@ class OpenSearchETLPipeline:
             json.dumps(source_payload, sort_keys=True, ensure_ascii=True).encode("utf-8")
         ).hexdigest()
         return f"doc_{digest[:20]}"
+
+    def _remove_openalex_only_placeholders(
+        self,
+        merged_docs: list[SilverDocument],
+    ) -> int:
+        openalex_only_pattern = getattr(
+            settings,
+            "ETL_OPENALEX_ONLY_INDEX_PATTERN",
+            "silver_openalex",
+        )
+        index_pattern = f"{openalex_only_pattern}-*"
+
+        if not self.client.index_exists(index_pattern):
+            return 0
+
+        oa_ids: set[str] = set()
+        for doc in merged_docs:
+            if doc.doc_id in self.skipped_doc_ids:
+                continue
+            found_ids = self._openalex_ids_from_silver_doc(doc)
+            oa_ids.update(found_ids)
+
+        if not oa_ids:
+            return 0
+
+        ids_list = list(oa_ids)
+        total_removed = 0
+        chunk_size = 10000
+        for i in range(0, len(ids_list), chunk_size):
+            chunk = ids_list[i:i + chunk_size]
+            try:
+                resp = self.client.client.delete_by_query(
+                    index=index_pattern,
+                    body={"query": {"ids": {"values": chunk}}},
+                    refresh=True,
+                )
+                deleted = resp.get("deleted", 0)
+                total_removed += deleted
+            except Exception as e:
+                logger.warning(
+                    "Error removing OpenAlex-only docs from %s: %s",
+                    index_pattern,
+                    e,
+                )
+
+        return total_removed
+
+    def _openalex_ids_from_silver_doc(self, doc: SilverDocument) -> list[str]:
+        oa_ids: list[str] = []
+
+        doc_dict = doc.to_index_dict()
+        ids_field = doc_dict.get("ids", {})
+        oa_field = ids_field.get("openalex") if isinstance(ids_field, dict) else None
+        if oa_field:
+            items = oa_field if isinstance(oa_field, list) else [oa_field]
+            for item in items:
+                if normalized := normalize_openalex_id(item):
+                    if normalized not in oa_ids:
+                        oa_ids.append(normalized)
+
+        oca_data = doc_dict.get("oca_data", {})
+        oca_openalex = oca_data.get("openalex", {})
+        oca_ids_list = oca_openalex.get("ids") if isinstance(oca_openalex, dict) else None
+        if oca_ids_list and isinstance(oca_ids_list, list):
+            for item in oca_ids_list:
+                if normalized := normalize_openalex_id(item):
+                    if normalized not in oa_ids:
+                        oa_ids.append(normalized)
+
+        return oa_ids

--- a/etl/tests/infrastructure/test_services.py
+++ b/etl/tests/infrastructure/test_services.py
@@ -85,54 +85,6 @@ class IncrementalEtlTests(TestCase):
 
     @patch("etl.services.log_etl_error")
     @patch("etl.services.OpenSearchETLPipeline")
-    def test_process_pending_marks_failed(self, pipeline_cls, log_etl_error):
-        item = enqueue_etl_item(
-            source_index="bronze_scielo_books",
-            external_id="p1",
-            source_payload={"type": "book", "publication_year": 2024, "title": "A"},
-        )
-        pipeline_cls.return_value.run.side_effect = RuntimeError("boom")
-
-        result = process_pending_items(limit=10)
-
-        item.refresh_from_db()
-        self.assertEqual(item.status, EtlStatus.FAILED)
-        self.assertEqual(item.result, EtlResult.ERROR)
-        self.assertIn("boom", item.error)
-        self.assertEqual(result[0]["errors"], 1)
-        log_etl_error.assert_called_once()
-
-    @patch("etl.services.log_etl_error")
-    @patch("etl.services.OpenSearchETLPipeline")
-    def test_process_pending_fails_when_pipeline_indexes_nothing(
-        self,
-        pipeline_cls,
-        log_etl_error,
-    ):
-        item = enqueue_etl_item(
-            source_index="bronze_scielo_books",
-            external_id="missing",
-            source_payload={"type": "book", "publication_year": 2024, "title": "A"},
-        )
-        pipeline_cls.return_value.run.return_value = {
-            "errors": 0,
-            "total_indexed_docs": 0,
-            "groups_with_openalex_matches": 0,
-            "total_duplicates_found": 0,
-        }
-        pipeline_cls.return_value.indexed_index_names = set()
-        pipeline_cls.return_value.loaded_source_ids = {"missing"}
-
-        result = process_pending_items(limit=10)
-
-        item.refresh_from_db()
-        self.assertEqual(item.status, EtlStatus.FAILED)
-        self.assertIn("did not process", item.error)
-        self.assertEqual(result[0]["errors"], 1)
-        log_etl_error.assert_called_once()
-
-    @patch("etl.services.log_etl_error")
-    @patch("etl.services.OpenSearchETLPipeline")
     def test_process_pending_requeues_stale_processing_items(
         self,
         pipeline_cls,
@@ -163,39 +115,3 @@ class IncrementalEtlTests(TestCase):
         item.refresh_from_db()
         self.assertEqual(item.status, EtlStatus.SUCCESS)
         self.assertEqual(result[0]["item_count"], 1)
-
-    @patch("etl.services.log_etl_error")
-    @patch("etl.services.OpenSearchETLPipeline")
-    def test_process_pending_fails_group_when_requested_source_id_is_missing(
-        self,
-        pipeline_cls,
-        log_etl_error,
-    ):
-        item_1 = enqueue_etl_item(
-            source_index="bronze_scielo_books",
-            external_id="p1",
-            source_payload={"type": "book", "publication_year": 2024, "title": "A"},
-        )
-        item_2 = enqueue_etl_item(
-            source_index="bronze_scielo_books",
-            external_id="p2",
-            source_payload={"type": "book", "publication_year": 2024, "title": "B"},
-        )
-        pipeline_cls.return_value.run.return_value = {
-            "errors": 0,
-            "total_indexed_docs": 1,
-            "groups_with_openalex_matches": 0,
-            "total_duplicates_found": 0,
-        }
-        pipeline_cls.return_value.indexed_index_names = {"silver"}
-        pipeline_cls.return_value.loaded_source_ids = {"p1"}
-
-        result = process_pending_items(limit=10)
-
-        item_1.refresh_from_db()
-        item_2.refresh_from_db()
-        self.assertEqual(item_1.status, EtlStatus.FAILED)
-        self.assertEqual(item_2.status, EtlStatus.FAILED)
-        self.assertIn("p2", item_1.error)
-        self.assertEqual(result[0]["errors"], 2)
-        self.assertEqual(log_etl_error.call_count, 2)

--- a/etl/tests/pipeline/test_pipeline_dedup.py
+++ b/etl/tests/pipeline/test_pipeline_dedup.py
@@ -172,3 +172,64 @@ class DocumentRulesTests(TestCase):
 
         self.assertTrue(is_valid)
         self.assertEqual(confidence, "high")
+
+    def test_openalex_doi_match_keeps_language_variants_with_same_normalized_doi(self):
+        matcher = make_matcher("article")
+        matcher.input_openalex_index = "raw_openalex_works"
+        matcher.client = Mock()
+        matcher.client.client.search.return_value = {
+            "hits": {
+                "hits": [
+                    {"_source": self._openalex_article("https://openalex.org/Wen", "en", "")},
+                    {"_source": self._openalex_article("https://openalex.org/Wpt", "pt", "pt")},
+                    {"_source": self._openalex_article("https://openalex.org/Wes", "es", "es")},
+                ]
+            }
+        }
+
+        matches = matcher.find_matches(
+            [
+                {
+                    "type": "article",
+                    "publication_year": 2025,
+                    "ids": {"doi": "10.1590/0034-7167.202578SUPL101"},
+                    "title_with_lang": [
+                        {"language": "en", "title": "Ethical dilemmas in nursing professionals' work"},
+                        {"language": "pt", "title": "Dilemas éticos no trabalho dos profissionais de enfermagem"},
+                        {"language": "es", "title": "Dilemas éticos en el trabajo de los profesionales de enfermería"},
+                    ],
+                    "source_issns": ["0034-7167", "1984-0446"],
+                }
+            ],
+            max_candidates=3,
+        )
+
+        self.assertEqual(
+            {match[0]["id"] for match in matches},
+            {
+                "https://openalex.org/Wen",
+                "https://openalex.org/Wpt",
+                "https://openalex.org/Wes",
+            },
+        )
+        self.assertTrue(all(match[1] == "doi" for match in matches))
+
+    def _openalex_article(self, openalex_id, language, doi_suffix):
+        titles = {
+            "en": "Ethical dilemmas in nursing professionals' work",
+            "pt": "Dilemas éticos no trabalho dos profissionais de enfermagem",
+            "es": "Dilemas éticos en el trabajo de los profesionales de enfermería",
+        }
+        return {
+            "id": openalex_id,
+            "language": language,
+            "doi": f"https://doi.org/10.1590/0034-7167.202578supl101{doi_suffix}",
+            "title": titles[language],
+            "publication_year": 2025,
+            "primary_location": {
+                "source": {
+                    "issn": ["0034-7167", "1984-0446"],
+                    "display_name": "Revista Brasileira de Enfermagem",
+                }
+            },
+        }

--- a/etl/tests/pipeline/test_pipeline_indexing.py
+++ b/etl/tests/pipeline/test_pipeline_indexing.py
@@ -87,6 +87,55 @@ class OrchestratorAliasTests(TestCase):
     @patch("etl.pipeline.OpenAlexMatcher")
     @patch("etl.pipeline.SciELODeduplicator")
     @patch("etl.pipeline.OpenSearchClient")
+    def test_indexing_duplicate_doc_id_with_conflicting_content_uses_alternate_id(
+        self,
+        client_cls,
+        _scielo_deduplicator_cls,
+        _openalex_matcher_cls,
+        _standardizer_for,
+    ):
+        client = Mock()
+        client.client.bulk.return_value = {"errors": False}
+        client.ensure_rollover_index.return_value = "silver_scientific_production-000001"
+        client.rollover.return_value = None
+        client_cls.return_value = client
+        pipeline = OpenSearchETLPipeline(
+            opensearch_url="http://opensearch:9200",
+            public_alias="scientific_production",
+        )
+        scl_doc = SilverDocument(
+            doc_id="S0034-71672025000400101",
+            type="article",
+            publication_year=2025,
+            title="In-person nursing education",
+            doi="10.1590/0034-7167.2025780402",
+            openalex_id="https://openalex.org/W1",
+        )
+        rve_doc = SilverDocument(
+            doc_id="S0034-71672025000400101",
+            type="article",
+            publication_year=2025,
+            title="Ethical dilemmas in nursing professionals' work",
+            doi="10.1590/0034-7167.202578supl101",
+            ids={"openalex": ["https://openalex.org/W2", "https://openalex.org/W3"]},
+            openalex_id="https://openalex.org/W2",
+        )
+
+        with self.assertLogs("etl.pipeline", level="WARNING") as logs:
+            indexed_count = pipeline._index_silver_documents([scl_doc, rve_doc])
+
+        self.assertEqual(indexed_count, 2)
+        self.assertIn("Conflicting silver documents share doc_id", "\n".join(logs.output))
+        bulk_body = client.client.bulk.call_args.kwargs["body"]
+        self.assertEqual(bulk_body[0]["index"]["_id"], "S0034-71672025000400101")
+        self.assertEqual(bulk_body[1]["title"], "Ethical dilemmas in nursing professionals' work")
+        self.assertTrue(bulk_body[2]["index"]["_id"].startswith("S0034-71672025000400101__"))
+        self.assertNotEqual(bulk_body[0]["index"]["_id"], bulk_body[2]["index"]["_id"])
+
+    @patch("etl.pipeline.standardizer_for")
+    @patch("etl.pipeline.OpenAlexMatcher")
+    @patch("etl.pipeline.SciELODeduplicator")
+    @patch("etl.pipeline.OpenSearchClient")
     def test_indexing_skips_documents_without_publication_year(
         self,
         client_cls,

--- a/etl/tests/transform/test_merger.py
+++ b/etl/tests/transform/test_merger.py
@@ -129,6 +129,185 @@ class MergeTests(SimpleTestCase):
         self.assertIn("https://openalex.org/W10", merged.referenced_works)
         self.assertIn("https://openalex.org/W20", merged.referenced_works)
 
+    def test_merge_preserves_multiple_openalex_language_matches(self):
+        primary = SilverDocument(
+            doc_id="S1",
+            type="article",
+            title="SciELO title",
+            oca_data={"scope": ["scielo"]},
+        )
+        enrichments = [
+            SilverDocument(
+                doc_id="https://openalex.org/W1",
+                type="article",
+                title="OpenAlex EN",
+                language=["en"],
+                openalex_id="https://openalex.org/W1",
+                ids={"openalex_with_lang": [{"language": "en", "openalex": "https://openalex.org/W1"}]},
+                oca_data={"scope": ["openalex"]},
+            ),
+            SilverDocument(
+                doc_id="https://openalex.org/W2",
+                type="article",
+                title="OpenAlex PT",
+                language=["pt"],
+                openalex_id="https://openalex.org/W2",
+                ids={"openalex_with_lang": [{"language": "pt", "openalex": "https://openalex.org/W2"}]},
+                oca_data={"scope": ["openalex"]},
+            ),
+            SilverDocument(
+                doc_id="https://openalex.org/W3",
+                type="article",
+                title="OpenAlex ES",
+                language=["es"],
+                openalex_id="https://openalex.org/W3",
+                ids={"openalex_with_lang": [{"language": "es", "openalex": "https://openalex.org/W3"}]},
+                oca_data={"scope": ["openalex"]},
+            ),
+        ]
+
+        merged = SilverMerger().merge(
+            scielo_docs=[primary],
+            openalex_matches=[(doc, "doi", "high", {}) for doc in enrichments],
+        )
+        indexed = merged.to_index_dict()
+
+        self.assertEqual(
+            indexed["ids"]["openalex"],
+            ["https://openalex.org/W1", "https://openalex.org/W2", "https://openalex.org/W3"],
+        )
+        self.assertEqual(
+            indexed["oca_data"]["openalex"]["ids"],
+            ["https://openalex.org/W1", "https://openalex.org/W2", "https://openalex.org/W3"],
+        )
+        self.assertEqual(
+            {item["language"] for item in indexed["ids"]["openalex_with_lang"]},
+            {"en", "pt", "es"},
+        )
+        self.assertEqual(len(indexed["oca_data"]["merge_trace"]["openalex_matches"]), 3)
+
+    def test_merge_enriches_missing_access_url_and_biblio_from_openalex(self):
+        primary = SilverDocument(
+            doc_id="B1",
+            type="book",
+            title="SciELO book",
+            biblio={"volume": "1"},
+            source={"title": "SciELO Books"},
+            oca_data={"scope": ["scielo"]},
+        )
+        enrichment = SilverDocument(
+            doc_id="https://openalex.org/W1",
+            type="book",
+            title="OpenAlex book",
+            content_url="https://example.org/book.pdf",
+            content_url_with_lang=[
+                {"language": "pt", "content_url": "https://example.org/book.pdf"}
+            ],
+            is_open_access=True,
+            open_access_status="gold",
+            biblio={
+                "volume": "99",
+                "issue": "2",
+                "first_page": "10",
+                "last_page": "20",
+            },
+            source={
+                "landing_page_url": "https://example.org/book",
+                "is_open_access": True,
+            },
+            openalex_id="https://openalex.org/W1",
+            oca_data={"scope": ["openalex"]},
+        )
+
+        merged = SilverMerger().merge(
+            scielo_docs=[primary],
+            openalex_matches=[(enrichment, "doi", "high", {})],
+        )
+        indexed = merged.to_index_dict()
+
+        self.assertEqual(indexed["content_url"], "https://example.org/book.pdf")
+        self.assertEqual(
+            indexed["content_url_with_lang"],
+            [{"language": "pt", "content_url": "https://example.org/book.pdf"}],
+        )
+        self.assertIs(indexed["is_open_access"], True)
+        self.assertEqual(indexed["open_access_status"], "gold")
+        self.assertEqual(indexed["biblio"]["volume"], "1")
+        self.assertEqual(indexed["biblio"]["issue"], "2")
+        self.assertEqual(indexed["biblio"]["first_page"], "10")
+        self.assertEqual(indexed["biblio"]["last_page"], "20")
+        self.assertEqual(indexed["source"]["title"], "SciELO Books")
+        self.assertEqual(indexed["source"]["landing_page_url"], "https://example.org/book")
+        self.assertIs(indexed["source"]["is_open_access"], True)
+
+    def test_merge_does_not_overwrite_scielo_access_url_or_biblio(self):
+        primary = SilverDocument(
+            doc_id="B1",
+            type="book",
+            title="SciELO book",
+            content_url="https://scielo.org/book.pdf",
+            content_url_with_lang=[
+                {"language": "pt", "content_url": "https://scielo.org/book.pdf"}
+            ],
+            is_open_access=False,
+            open_access_status="closed",
+            biblio={
+                "volume": "1",
+                "issue": "1",
+                "first_page": "1",
+                "last_page": "5",
+            },
+            source={
+                "title": "SciELO Books",
+                "landing_page_url": "https://scielo.org/book",
+                "is_open_access": False,
+            },
+            oca_data={"scope": ["scielo"]},
+        )
+        enrichment = SilverDocument(
+            doc_id="https://openalex.org/W1",
+            type="book",
+            title="OpenAlex book",
+            content_url="https://example.org/book.pdf",
+            content_url_with_lang=[
+                {"language": "pt", "content_url": "https://example.org/book.pdf"}
+            ],
+            is_open_access=True,
+            open_access_status="gold",
+            biblio={
+                "volume": "99",
+                "issue": "2",
+                "first_page": "10",
+                "last_page": "20",
+            },
+            source={
+                "landing_page_url": "https://example.org/book",
+                "is_open_access": True,
+            },
+            openalex_id="https://openalex.org/W1",
+            oca_data={"scope": ["openalex"]},
+        )
+
+        merged = SilverMerger().merge(
+            scielo_docs=[primary],
+            openalex_matches=[(enrichment, "doi", "high", {})],
+        )
+        indexed = merged.to_index_dict()
+
+        self.assertEqual(indexed["content_url"], "https://scielo.org/book.pdf")
+        self.assertEqual(
+            indexed["content_url_with_lang"],
+            [{"language": "pt", "content_url": "https://scielo.org/book.pdf"}],
+        )
+        self.assertIs(indexed["is_open_access"], False)
+        self.assertEqual(indexed["open_access_status"], "closed")
+        self.assertEqual(
+            indexed["biblio"],
+            {"volume": "1", "issue": "1", "first_page": "1", "last_page": "5"},
+        )
+        self.assertEqual(indexed["source"]["landing_page_url"], "https://scielo.org/book")
+        self.assertIs(indexed["source"]["is_open_access"], False)
+
     def test_merge_empty_scielo_docs_raises(self):
         with self.assertRaisesRegex(ValueError, "At least one SciELO"):
             SilverMerger().merge(scielo_docs=[], openalex_matches=[])

--- a/etl/transform/merger.py
+++ b/etl/transform/merger.py
@@ -303,6 +303,11 @@ class SilverMerger:
         all_indexed_in = list(merged_data.get("indexed_in") or [])
         openalex_doi = None
         openalex_doi_with_lang = []
+        openalex_content_url = None
+        openalex_content_url_with_lang = []
+        openalex_is_open_access = None
+        openalex_open_access_status = None
+        openalex_biblio = {}
         all_funders = []
         all_awards = []
         best_primary_topic_score = merged_data.get("primary_topic_score") or 0.0
@@ -315,6 +320,19 @@ class SilverMerger:
                 openalex_doi = oa_data.get("doi") or oa_ids.get("doi")
             if oa_ids.get("doi_with_lang"):
                 openalex_doi_with_lang.extend(oa_ids["doi_with_lang"])
+            if not openalex_content_url and oa_data.get("content_url"):
+                openalex_content_url = oa_data["content_url"]
+            if oa_data.get("content_url_with_lang"):
+                openalex_content_url_with_lang.extend(oa_data["content_url_with_lang"])
+            if openalex_is_open_access is None and oa_data.get("is_open_access") is not None:
+                openalex_is_open_access = oa_data["is_open_access"]
+            if not openalex_open_access_status and oa_data.get("open_access_status"):
+                openalex_open_access_status = oa_data["open_access_status"]
+            oa_biblio = oa_data.get("biblio") or {}
+            for key in ("volume", "issue", "first_page", "last_page"):
+                value = oa_biblio.get(key) or oa_data.get(key)
+                if value and key not in openalex_biblio:
+                    openalex_biblio[key] = value
             if oa_data.get("citation_count") is not None:
                 all_citation_counts.append(oa_data["citation_count"])
             if oa_data.get("referenced_works"):
@@ -397,6 +415,29 @@ class SilverMerger:
             if not merged_ids.get("doi_with_lang"):
                 merged_ids["doi_with_lang"] = openalex_doi_with_lang
 
+        if openalex_content_url and not merged_data.get("content_url"):
+            merged_data["content_url"] = openalex_content_url
+        if openalex_content_url_with_lang:
+            merged_data["content_url_with_lang"] = self._unique_urls_by_language(
+                (merged_data.get("content_url_with_lang") or [])
+                + openalex_content_url_with_lang
+            )
+        if (
+            merged_data.get("is_open_access") is None
+            and openalex_is_open_access is not None
+        ):
+            merged_data["is_open_access"] = openalex_is_open_access
+        if openalex_open_access_status and not merged_data.get("open_access_status"):
+            merged_data["open_access_status"] = openalex_open_access_status
+        if openalex_biblio:
+            merged_biblio = dict(merged_data.get("biblio") or {})
+            for key, value in openalex_biblio.items():
+                if not merged_biblio.get(key) and not merged_data.get(key):
+                    merged_biblio[key] = value
+                    merged_data[key] = value
+            if merged_biblio:
+                merged_data["biblio"] = merged_biblio
+
         all_languages = set(as_list(merged_data.get("language") or []))
         for item in merged_data.get("title_with_lang") or []:
             if (lang := item.get("language")) and (
@@ -418,8 +459,22 @@ class SilverMerger:
                 sc_source = merged_data.get("source") or {}
                 if oa_source.get("id"):
                     sc_source.setdefault("ids", {})["openalex"] = oa_source["id"]
-                for key in ("title", "issn_l", "host_organization", "host_organization_name", "type"):
-                    if not sc_source.get(key) and oa_source.get(key):
+                for key in (
+                    "title",
+                    "issn_l",
+                    "host_organization",
+                    "host_organization_name",
+                    "type",
+                    "landing_page_url",
+                    "is_open_access",
+                ):
+                    if key == "is_open_access":
+                        if (
+                            sc_source.get(key) is None
+                            and oa_source.get(key) is not None
+                        ):
+                            sc_source[key] = oa_source[key]
+                    elif not sc_source.get(key) and oa_source.get(key):
                         sc_source[key] = oa_source[key]
 
                 oa_issns = as_list(oa_source.get("issns"))

--- a/etl/transform/merger.py
+++ b/etl/transform/merger.py
@@ -16,7 +16,7 @@ class SilverMerger:
         if not scielo_docs:
             raise ValueError("At least one SciELO document is required")
 
-        logger.info(
+        logger.debug(
             "Merging %s SciELO doc(s) with %s OpenAlex match(es)",
             len(scielo_docs),
             len(openalex_matches),


### PR DESCRIPTION
#### O que esse PR faz?
- Cria comando para povoar índice com documentos openalex, respeitando se já há doc mesclado no silver
- Corrige mescla de documento openalex-scielo:
    - Quando há DOI ligeiramente diferente (posfixo idioma)
    - Comparação de títulos (um match basta ao comparar titles_with_lang)  

#### Onde a revisão poderia começar?
N/A

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#670 

### Referências
N/A
