### PR TITLE
Cria botão para abrir tela de busca a partir de tela de indicadores

### DIFF
--- a/indicator/models.py
+++ b/indicator/models.py
@@ -26,6 +26,7 @@ from core.utils import utils
 from indicator.metrics.config import ComputedMetric, MetricGroup, PhysicalMetric
 from institution.models import Institution
 from location.models import Location
+from search.models import SearchPage
 from search_gateway.filter_ui import build_data_source_form_payload, render_filter_sidebar
 from search_gateway.request_filters import extract_applied_filters
 from usefulmodels.models import ActionAndPractice, ThematicArea
@@ -926,6 +927,19 @@ class ChartBasePage(Page):
     class Meta:
         abstract = True
 
+    def get_search_page_url(self):
+        qs = SearchPage.objects.filter(live=True, data_source=self.data_source)
+
+        if getattr(self, "locale_id", None):
+            localized = qs.filter(locale_id=self.locale_id).first()
+
+            if localized:
+                return localized.url
+
+        page = qs.first()
+
+        return page.url if page else ""
+
     def get_indicator_nav_urls(self):
         urls = {"indicator_home_url": self.url}
         navigation = (self.data_source.metric_config_schema or {}).get("navigation") or {}
@@ -1106,6 +1120,7 @@ class ChartBasePage(Page):
             "analysis_unit_options": analysis_unit_options,
             "study_unit": study_unit,
             "charts": charts,
+            "search_page_url": self.get_search_page_url(),
         })
         context.update(self.get_indicator_nav_urls())
         context["applied_filters_json"] = json.dumps(context["applied_filters"])

--- a/indicator/static/indicator/css/custom.css
+++ b/indicator/static/indicator/css/custom.css
@@ -71,6 +71,55 @@
   margin-left: auto;
 }
 
+.indicator-controls-bar__search-section {
+  padding-top: 0.95rem;
+  border-top: 1px solid #ebf0f6;
+}
+
+.indicator-controls-bar__search-total-row {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.indicator-controls-bar__search-total {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1e3a5f;
+  font-variant-numeric: tabular-nums;
+}
+
+.indicator-controls-bar__search-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.65rem;
+  height: 1.65rem;
+  padding: 0;
+  border: 1px solid #c8d8f2;
+  border-radius: 4px;
+  background: var(--sg-accent-soft, #eef4ff);
+  cursor: pointer;
+  transition: background-color 0.16s ease, border-color 0.16s ease;
+}
+
+.indicator-controls-bar__search-icon::before {
+  content: "";
+  display: block;
+  width: 0.92rem;
+  height: 0.92rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 16 16' fill='none'%3E%3Ccircle cx='7' cy='7' r='4.5' stroke='%232F4EA1' stroke-width='1.35'/%3E%3Cpath d='M10.5 10.5L14 14' stroke='%232F4EA1' stroke-width='1.35' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+
+.indicator-controls-bar__search-icon:hover,
+.indicator-controls-bar__search-icon:focus-visible {
+  background: #dfe9ff;
+  border-color: #b8caef;
+}
+
 .indicator-controls-bar__form {
   margin: 0;
 }
@@ -81,6 +130,7 @@
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: #8fa2b8;
+  font-family: 'Poppins', sans-serif;
 }
 
 .indicator-controls-bar__section-title--label {

--- a/indicator/static/indicator/js/menu.js
+++ b/indicator/static/indicator/js/menu.js
@@ -368,9 +368,51 @@ function updateSearchButtonTotal(total) {
   el.textContent = typeof total === 'number' ? total.toLocaleString() : total;
 }
 
+function initGoToSearchButton() {
+  const btn = document.getElementById('indicator-go-to-search');
+  if (!btn) return;
+
+  btn.addEventListener('click', (event) => {
+    event.preventDefault();
+
+    const searchUrl = (btn.dataset.searchUrl || '').trim();
+    if (!searchUrl) return;
+
+    const menuForm = document.getElementById('indicator-filter-form');
+    const filters = menuForm && window.SearchGatewayFilterForm
+      ? window.SearchGatewayFilterForm.serializeForm(menuForm)
+      : {};
+
+    const scopeFromUrl = getScopeFilterFromUrl();
+    const existingScope = filters.scope;
+    const hasScopeInFilters = Array.isArray(existingScope)
+      ? existingScope.some(v => String(v || '').trim())
+      : !!String(existingScope || '').trim();
+    if (!hasScopeInFilters && scopeFromUrl) {
+      filters.scope = scopeFromUrl;
+    }
+
+    delete filters.breakdown_variable;
+
+    const params = new URLSearchParams();
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value == null || value === '') return;
+      if (Array.isArray(value)) {
+        value.forEach(v => { if (v != null && v !== '') params.append(key, v); });
+      } else {
+        params.append(key, value);
+      }
+    });
+
+    const query = params.toString();
+    window.open(query ? `${searchUrl}?${query}` : searchUrl, '_blank');
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initIndicatorControlBarSelects();
   initScopeControls();
+  initGoToSearchButton();
 });
 
 if (typeof window !== 'undefined' && typeof window.gettext !== 'function') {

--- a/indicator/static/indicator/js/menu.js
+++ b/indicator/static/indicator/js/menu.js
@@ -310,6 +310,14 @@ function initIndicatorForm(dataSource, studyUnit) {
 
       clearAppliedFiltersContainer();
       renderChartsContainer(data, dataSource, studyUnit, formData.get('csrfmiddlewaretoken'));
+
+      const firstChart = Array.isArray(data.charts) && data.charts.find(c => !c.is_relative);
+      if (firstChart) {
+        const total = (firstChart.series || []).reduce(
+          (sum, s) => sum + (s.data || []).reduce((a, b) => a + (Number(b) || 0), 0), 0
+        );
+        updateSearchButtonTotal(total);
+      }
     })
     .catch(error => {
       console.error('Error:', error);
@@ -352,6 +360,12 @@ function initIndicatorForm(dataSource, studyUnit) {
   } else {
     window.setTimeout(triggerInitialRender, 250);
   }
+}
+
+function updateSearchButtonTotal(total) {
+  const el = document.getElementById('indicator-search-total');
+  if (!el) return;
+  el.textContent = typeof total === 'number' ? total.toLocaleString() : total;
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/indicator/templates/controls_bar.html
+++ b/indicator/templates/controls_bar.html
@@ -104,7 +104,7 @@
       >
       <div class="indicator-controls-bar__config-head">
         <div class="indicator-controls-bar__config-intro">
-          <div class="indicator-controls-bar__section-title indicator-controls-bar__config-title">{% trans "Ranking setup" %}</div>
+          <div class="indicator-controls-bar__section-title indicator-controls-bar__section-title--label indicator-controls-bar__config-title">{% trans "Ranking setup" %}</div>
           <p class="indicator-controls-bar__config-text">
             {% trans "Configuration values that shape the ranking before the lateral filters refine the result set." %}
           </p>

--- a/indicator/templates/controls_bar.html
+++ b/indicator/templates/controls_bar.html
@@ -78,6 +78,23 @@
     </div>
   </div>
 
+  {% if search_page_url and study_unit == "document" %}
+    <div class="indicator-controls-bar__search-section">
+      <div class="indicator-controls-bar__section-title indicator-controls-bar__section-title--label">{% trans "Total documents" %}</div>
+      <div class="indicator-controls-bar__search-total-row">
+        <span class="indicator-controls-bar__search-total" id="indicator-search-total">&mdash;</span>
+        <button
+          type="button"
+          id="indicator-go-to-search"
+          class="indicator-controls-bar__search-icon"
+          data-search-url="{{ search_page_url }}"
+          title="{% trans 'Search documents with current filters' %}"
+          aria-label="{% trans 'Search documents' %}"
+        ></button>
+      </div>
+    </div>
+  {% endif %}
+
   {% if indicator_config_fields %}
       <div
         class="indicator-controls-bar__config"


### PR DESCRIPTION
#### O que esse PR faz?
Cria um label para apresentar o total de documentos relacionados aos filtros aplicados seguido de uma lupa, que abre a tela de busca com o mesmo conjunto de filtros.

#### Onde a revisão poderia começar?
A partir do primeiro commit.

#### Como este poderia ser testado manualmente?
1. Instancie o sistema
2. Acesse a tela de indicadores
3. Aplique filtros
4. Veja o total de documentos
5. Clique na lupa para ir à tela de busca
6. Observe o mesmo total de documentos

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
<img width="2105" height="1150" alt="image" src="https://github.com/user-attachments/assets/069cadab-8d32-4938-98f3-28ef50b92a9e" />

#### Quais são tickets relevantes?
#479 

### Referências
N/A

