### PR TITLE
Corrige lookup builders, melhora dinamismo e inclui N na aba de filtros

### DIFF
--- a/core/fixtures/pages.json
+++ b/core/fixtures/pages.json
@@ -52,7 +52,7 @@
           "title": "Métricas Temáticas de Periódicos",
           "type": "IndicatorByCategoryPage",
           "slug": "metricas-tematicas-periodicos",
-          "data_source": "journal_thematic_metrics",
+          "data_source": "journal_metrics_by_*",
           "intro": "<p>Análise temática de periódicos por área do conhecimento.</p>",
           "children": [
             {
@@ -60,7 +60,7 @@
               "title": "Perfil de Periódico",
               "type": "JournalProfilePage",
               "slug": "perfil-periodico",
-              "data_source": "journal_thematic_metrics",
+              "data_source": "journal_metrics_by_*",
               "show_global_metrics": true
             }
           ]
@@ -70,15 +70,17 @@
           "title": "Métricas Globais de Periódicos",
           "type": "IndicatorGlobalPage",
           "slug": "metricas-globais-periodicos",
-          "data_source": "journal_global_metrics",
+          "data_source": "journal_metrics_global_*",
           "intro": "<p>Métricas globais comparativas de periódicos científicos.</p>"
         },
         {
           "key": "indicators_social_production",
           "title": "Produção Social",
-          "type": "FreePage",
+          "type": "DocumentChartPage",
           "slug": "producao-social",
-          "intro": "<p>Visualize métricas e indicadores da produção social.</p>"
+          "data_source": "social_production",
+          "study_unit": "document",
+          "intro": "<p>Visualize métricas e indicadores da produção social baseada em registros.</p>"
         }
       ]
     },
@@ -211,7 +213,7 @@
           "title": "Journal Thematic Metrics",
           "type": "IndicatorByCategoryPage",
           "slug": "journal-thematic-metrics",
-          "data_source": "journal_thematic_metrics",
+          "data_source": "journal_metrics_by_*",
           "intro": "<p>Thematic analysis of journals by knowledge area.</p>",
           "children": [
             {
@@ -219,7 +221,7 @@
               "title": "Journal Profile",
               "type": "JournalProfilePage",
               "slug": "journal-profile",
-              "data_source": "journal_thematic_metrics",
+              "data_source": "journal_metrics_by_*",
               "show_global_metrics": true
             }
           ]
@@ -229,15 +231,17 @@
           "title": "Journal Global Metrics",
           "type": "IndicatorGlobalPage",
           "slug": "journal-global-metrics",
-          "data_source": "journal_global_metrics",
+          "data_source": "journal_metrics_global_*",
           "intro": "<p>Global comparative metrics for scientific journals.</p>"
         },
         {
           "key": "indicators_social_production",
           "title": "Social Production",
-          "type": "FreePage",
+          "type": "DocumentChartPage",
           "slug": "social-production",
-          "intro": "<p>View metrics and indicators for social production.</p>"
+          "data_source": "social_production",
+          "study_unit": "document",
+          "intro": "<p>View metrics and indicators for record-based social production.</p>"
         }
       ]
     },
@@ -370,7 +374,7 @@
           "title": "Métricas Temáticas de Revistas",
           "type": "IndicatorByCategoryPage",
           "slug": "metricas-tematicas-revistas",
-          "data_source": "journal_thematic_metrics",
+          "data_source": "journal_metrics_by_*",
           "intro": "<p>Análisis temático de revistas por área del conocimiento.</p>",
           "children": [
             {
@@ -378,7 +382,7 @@
               "title": "Perfil de Revista",
               "type": "JournalProfilePage",
               "slug": "perfil-revista",
-              "data_source": "journal_thematic_metrics",
+              "data_source": "journal_metrics_by_*",
               "show_global_metrics": true
             }
           ]
@@ -388,15 +392,17 @@
           "title": "Métricas Globales de Revistas",
           "type": "IndicatorGlobalPage",
           "slug": "metricas-globales-revistas",
-          "data_source": "journal_global_metrics",
+          "data_source": "journal_metrics_global_*",
           "intro": "<p>Métricas globales comparativas de revistas científicas.</p>"
         },
         {
           "key": "indicators_social_production",
           "title": "Producción Social",
-          "type": "FreePage",
+          "type": "DocumentChartPage",
           "slug": "produccion-social",
-          "intro": "<p>Visualice métricas e indicadores de la producción social.</p>"
+          "data_source": "social_production",
+          "study_unit": "document",
+          "intro": "<p>Visualice métricas e indicadores de la producción social basada en registros.</p>"
         }
       ]
     },

--- a/search_gateway/fixtures/datasources.json
+++ b/search_gateway/fixtures/datasources.json
@@ -27,7 +27,30 @@
               "support_query_operator": false,
               "include_all_option": true,
               "all_option_label": "All",
-              "search_threshold": 10
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "source_indexed_in": {
@@ -49,7 +72,30 @@
               "group_order": 0,
               "include_all_option": true,
               "all_option_label": "All",
-              "search_threshold": 10
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "source_scielo_indexed_in": {
@@ -70,7 +116,30 @@
               "group_order": 0,
               "include_all_option": true,
               "all_option_label": "All",
-              "search_threshold": 10
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "collection": {
@@ -91,7 +160,30 @@
               "search_threshold": 10,
               "display_transform": "scielo_collection",
               "group": "coverage",
-              "group_order": 0
+              "group_order": 0,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "publication_year": {
@@ -109,7 +201,30 @@
               "widget": "select",
               "multiple_selection": true,
               "group": "document",
-              "group_order": 10
+              "group_order": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "document_publication_year_start": {
@@ -197,7 +312,30 @@
               "group_order": 10,
               "include_all_option": true,
               "all_option_label": "All",
-              "search_threshold": 10
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "document_language": {
@@ -219,7 +357,30 @@
               "group_order": 10,
               "include_all_option": true,
               "all_option_label": "All",
-              "search_threshold": 10
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "open_access": {
@@ -241,7 +402,30 @@
               "multiple_selection": false,
               "widget": "select",
               "group": "document",
-              "group_order": 10
+              "group_order": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "open_access_status": {
@@ -263,7 +447,30 @@
               "group_order": 10,
               "include_all_option": true,
               "all_option_label": "All",
-              "search_threshold": 10
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "source_name": {
@@ -284,7 +491,30 @@
               "group": "source",
               "group_order": 20,
               "include_all_option": true,
-              "all_option_label": "All"
+              "all_option_label": "All",
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             },
             "lookup": {
               "index_name": "silver_lookup_source",
@@ -294,6 +524,18 @@
               "label_field": "label",
               "source_value_field": "label",
               "source_label_field": "label",
+              "dependency_filters": {
+                "document_type": "document_types",
+                "document_language": "document_languages",
+                "open_access": "open_access_values",
+                "open_access_status": "open_access_statuses",
+                "source_type": "source_type",
+                "publisher": "publisher_names",
+                "source_country": "source_country_codes",
+                "source_indexed_in": "indexed_in",
+                "source_scielo_indexed_in": "source_scielo_indexed_in",
+                "collection": "collections"
+              },
               "size": 10
             }
           },
@@ -316,7 +558,30 @@
               "group_order": 20,
               "include_all_option": true,
               "all_option_label": "All",
-              "search_threshold": 10
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "publisher": {
@@ -337,7 +602,30 @@
               "group": "source",
               "group_order": 20,
               "include_all_option": true,
-              "all_option_label": "All"
+              "all_option_label": "All",
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             },
             "lookup": {
               "index_name": "silver_lookup_publisher",
@@ -347,6 +635,18 @@
               "label_field": "label",
               "source_value_field": "value",
               "source_label_field": "label",
+              "dependency_filters": {
+                "source_name": "source_names",
+                "source_type": "source_types",
+                "source_country": "source_country_codes",
+                "source_indexed_in": "indexed_in",
+                "source_scielo_indexed_in": "source_scielo_indexed_in",
+                "collection": "collections",
+                "document_type": "document_types",
+                "document_language": "document_languages",
+                "open_access": "open_access_values",
+                "open_access_status": "open_access_statuses"
+              },
               "size": 10
             }
           },
@@ -366,7 +666,30 @@
               "widget": "select",
               "multiple_selection": true,
               "group": "source",
-              "group_order": 20
+              "group_order": 20,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "primary_topic_domain": {
@@ -387,7 +710,31 @@
               "group": "thematic",
               "group_order": 30,
               "include_all_option": true,
-              "all_option_label": "All"
+              "all_option_label": "All",
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "primary_topic_domain",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ],
+              "lookup_use_data_source_values": true
             },
             "lookup": {
               "index_name": "silver_lookup_topic",
@@ -423,7 +770,31 @@
               "group": "thematic",
               "group_order": 30,
               "include_all_option": true,
-              "all_option_label": "All"
+              "all_option_label": "All",
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "primary_topic_field",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ],
+              "lookup_use_data_source_values": true
             },
             "lookup": {
               "index_name": "silver_lookup_topic",
@@ -459,7 +830,31 @@
               "group": "thematic",
               "group_order": 30,
               "include_all_option": true,
-              "all_option_label": "All"
+              "all_option_label": "All",
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_name",
+                "primary_topic_subfield",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ],
+              "lookup_use_data_source_values": true
             },
             "lookup": {
               "index_name": "silver_lookup_topic",
@@ -495,7 +890,31 @@
               "group": "thematic",
               "group_order": 30,
               "include_all_option": true,
-              "all_option_label": "All"
+              "all_option_label": "All",
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ],
+              "lookup_use_data_source_values": true
             },
             "lookup": {
               "index_name": "silver_lookup_topic",
@@ -531,7 +950,30 @@
               "group_order": 30,
               "include_all_option": true,
               "all_option_label": "All",
-              "search_threshold": 10
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "institution": {
@@ -552,7 +994,30 @@
               "group": "affiliation_funding",
               "group_order": 40,
               "include_all_option": true,
-              "all_option_label": "All"
+              "all_option_label": "All",
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             },
             "lookup": {
               "index_name": "silver_lookup_institution",
@@ -562,6 +1027,15 @@
               "label_field": "label",
               "source_value_field": "value",
               "source_label_field": "label",
+              "dependency_filters": {
+                "country": "country_codes",
+                "sdg": "sdg_names",
+                "funder": "funder_ids",
+                "document_type": "document_types",
+                "document_language": "document_languages",
+                "open_access": "open_access_values",
+                "open_access_status": "open_access_statuses"
+              },
               "size": 10
             }
           },
@@ -584,7 +1058,30 @@
               "group_order": 40,
               "include_all_option": true,
               "all_option_label": "All",
-              "search_threshold": 10
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             }
           },
           "funder": {
@@ -605,7 +1102,30 @@
               "group": "affiliation_funding",
               "group_order": 40,
               "include_all_option": true,
-              "all_option_label": "All"
+              "all_option_label": "All",
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "funder"
+              ]
             },
             "lookup": {
               "index_name": "silver_lookup_funder",
@@ -615,6 +1135,15 @@
               "label_field": "label",
               "source_value_field": "value",
               "source_label_field": "label",
+              "dependency_filters": {
+                "sdg": "sdg_names",
+                "country": "country_codes",
+                "institution": "institution_names",
+                "document_type": "document_types",
+                "document_language": "document_languages",
+                "open_access": "open_access_values",
+                "open_access_status": "open_access_statuses"
+              },
               "size": 10
             }
           },
@@ -867,7 +1396,7 @@
               },
               "url_context_key": "journal_thematic_url",
               "return_to_source": true,
-              "target_data_source": "journal_thematic_metrics"
+              "target_data_source": "journal_metrics_by_*"
             },
             {
               "value": "journal_global_metrics",
@@ -878,7 +1407,7 @@
               },
               "url_context_key": "journal_global_url",
               "enabled": false,
-              "target_data_source": "journal_global_metrics"
+              "target_data_source": "journal_metrics_global_*"
             }
           ]
         },
@@ -1556,7 +2085,7 @@
         "forms": {
           "search": {
             "group_labels": {
-              "document": "Document",
+              "document": "Record",
               "activity_profile": "Activity Profile",
               "thematic": "Thematic",
               "affiliation": "Affiliation",
@@ -1581,7 +2110,7 @@
           "indicator": {
             "group_labels": {
               "graph_options": "Graph Options",
-              "document": "Document",
+              "document": "Record",
               "activity_profile": "Activity Profile",
               "thematic": "Thematic",
               "affiliation": "Affiliation",
@@ -1605,6 +2134,60 @@
             ]
           }
         }
+      },
+      "metric_config": {
+        "navigation": {
+          "analysis_units": [
+            {
+              "value": "document",
+              "label": {
+                "pt": "Registro",
+                "en": "Record",
+                "es": "Registro"
+              },
+              "url_context_key": "indicator_home_url"
+            }
+          ]
+        },
+        "comparison": {
+          "enabled": false
+        },
+        "study_units": {
+          "document": {
+            "time_dimension": {
+              "field": "publication_year",
+              "agg_type": "terms"
+            },
+            "metrics": [
+              {
+                "key": "record_count",
+                "agg": "count",
+                "label": {
+                  "pt": "Registros",
+                  "en": "Records",
+                  "es": "Registros"
+                }
+              }
+            ]
+          }
+        },
+        "displays": {
+          "charts": {
+            "record_total_records": {
+              "metric": "record_count",
+              "title": {
+                "pt": "Total de Registros por Ano",
+                "en": "Total Records per Year",
+                "es": "Total de Registros por Año"
+              },
+              "type": "bar",
+              "order": 10,
+              "study_units": [
+                "document"
+              ]
+            }
+          }
+        }
       }
     }
   },
@@ -1612,7 +2195,7 @@
     "model": "search_gateway.datasource",
     "pk": 3,
     "fields": {
-      "index_name": "journal_thematic_metrics",
+      "index_name": "journal_metrics_by_*",
       "display_name": "Journal Thematic Metrics",
       "source_fields": [],
       "field_settings": {
@@ -2560,7 +3143,7 @@
             "thematic": "journal_metrics",
             "global": "journal_metrics_global"
           },
-          "related_global_data_source": "journal_global_metrics",
+          "related_global_data_source": "journal_metrics_global_*",
           "profile_query_params": [
             "collection",
             "publication_year",
@@ -2600,7 +3183,7 @@
               },
               "url_context_key": "journal_thematic_url",
               "return_to_source": true,
-              "target_data_source": "journal_thematic_metrics"
+              "target_data_source": "journal_metrics_by_*"
             },
             {
               "value": "journal_global_metrics",
@@ -2611,7 +3194,7 @@
               },
               "url_context_key": "journal_global_url",
               "enabled": false,
-              "target_data_source": "journal_global_metrics"
+              "target_data_source": "journal_metrics_global_*"
             }
           ]
         },
@@ -3140,7 +3723,7 @@
     "model": "search_gateway.datasource",
     "pk": 4,
     "fields": {
-      "index_name": "journal_global_metrics",
+      "index_name": "journal_metrics_global_*",
       "display_name": "Journal Global Metrics",
       "source_fields": [],
       "field_settings": {
@@ -4816,7 +5399,7 @@
               },
               "url_context_key": "journal_thematic_url",
               "return_to_source": true,
-              "target_data_source": "journal_thematic_metrics"
+              "target_data_source": "journal_metrics_by_*"
             },
             {
               "value": "journal_global_metrics",
@@ -4827,7 +5410,7 @@
               },
               "url_context_key": "journal_global_url",
               "enabled": false,
-              "target_data_source": "journal_global_metrics"
+              "target_data_source": "journal_metrics_global_*"
             }
           ]
         },

--- a/search_gateway/lookup/base.py
+++ b/search_gateway/lookup/base.py
@@ -7,7 +7,7 @@ from typing import Any
 from django.conf import settings
 from opensearchpy.helpers import scan, streaming_bulk
 
-from search_gateway.option_normalization import clean_text, normalize_text
+from search_gateway.option_normalization import clean_text, normalize_boolean, normalize_text
 from search_gateway.opensearch import OpenSearchIndexClient
 
 logger = logging.getLogger(__name__)
@@ -91,7 +91,30 @@ class LookupBuilder:
                 if isinstance(item, dict):
                     yield item
 
-    def count(self) -> int:
+    @staticmethod
+    def clean_boolean_value(value):
+        normalized = normalize_boolean(value)
+        if normalized is True:
+            return "true"
+
+        if normalized is False:
+            return "false"
+
+        return ""
+
+    @classmethod
+    def iter_clean_boolean_values(cls, value):
+        if isinstance(value, (list, tuple, set)):
+            for item in value:
+                cleaned = cls.clean_boolean_value(item)
+                if cleaned:
+                    yield cleaned
+            return
+
+        cleaned = cls.clean_boolean_value(value)
+        if cleaned:
+            yield cleaned
+
         return len(self.entries)
 
     @staticmethod

--- a/search_gateway/lookup/base.py
+++ b/search_gateway/lookup/base.py
@@ -115,6 +115,19 @@ class LookupBuilder:
         if cleaned:
             yield cleaned
 
+    def collect_document_metadata(self, source):
+        return {
+            "document_types": set(self.iter_clean_values(source.get("type"))),
+            "document_languages": set(self.iter_clean_values(source.get("language"))),
+            "open_access_values": set(
+                self.iter_clean_boolean_values(source.get("is_open_access"))
+            ),
+            "open_access_statuses": set(
+                self.iter_clean_values(source.get("open_access_status"))
+            ),
+        }
+
+    def count(self):
         return len(self.entries)
 
     @staticmethod
@@ -470,5 +483,3 @@ class LookupIndexBuildService:
             indexed_counts["_errors"] = error_counts
 
         return indexed_counts
-
-

--- a/search_gateway/lookup/builders/funder.py
+++ b/search_gateway/lookup/builders/funder.py
@@ -7,25 +7,48 @@ from search_gateway.lookup.base import LookupBuilder, clean_text
 class FunderLookupBuilder(LookupBuilder):
     key = "funder"
     default_index_name = "silver_lookup_funder"
-    source_fields = ["funders.name", "funders.id", "funders.ror"]
+    source_fields = [
+        "author_country_codes",
+        "funders.name",
+        "funders.id",
+        "funders.ror",
+        "institutions",
+        "is_open_access",
+        "language",
+        "open_access_status",
+        "sdg_names",
+        "type",
+    ]
+
     @property
     def mapping(self) -> dict[str, Any]:
         return self.build_mapping(
             {
                 "funder_id": {"type": "keyword"},
                 "funder_ror": {"type": "keyword"},
+                "sdg_names": {"type": "keyword"},
+                "country_codes": {"type": "keyword"},
+                "institution_names": {"type": "keyword"},
+                "document_types": {"type": "keyword"},
+                "document_languages": {"type": "keyword"},
+                "open_access_values": {"type": "keyword"},
+                "open_access_statuses": {"type": "keyword"},
             }
         )
 
     def collect(self, source: dict[str, Any], max_items: int | None = None) -> None:
         seen_values: set[str] = set()
+        sdg_names = set(self.iter_clean_values(source.get("sdg_names")))
+        country_codes = set(self.iter_clean_values(source.get("author_country_codes")))
+        institution_names = set(self.iter_clean_values(source.get("institutions")))
+        document_metadata = self.collect_document_metadata(source)
 
         for funder in self.iter_objects(source.get("funders")):
             funder_id = clean_text(funder.get("id"))
             if not funder_id:
                 continue
 
-            self.add_entry(
+            entry = self.add_entry(
                 funder_id,
                 clean_text(funder.get("name")),
                 seen_values,
@@ -33,6 +56,12 @@ class FunderLookupBuilder(LookupBuilder):
                 funder_id=funder_id,
                 funder_ror=clean_text(funder.get("ror")),
             )
+            if entry:
+                entry.setdefault("sdg_names", set()).update(sdg_names)
+                entry.setdefault("country_codes", set()).update(country_codes)
+                entry.setdefault("institution_names", set()).update(institution_names)
+                for field_name, values in document_metadata.items():
+                    entry.setdefault(field_name, set()).update(values)
 
     def iter_actions(self, index_name: str) -> Iterable[dict[str, Any]]:
         for action in super().iter_actions(index_name):
@@ -41,6 +70,21 @@ class FunderLookupBuilder(LookupBuilder):
                 {
                     "funder_id": entry.get("funder_id", ""),
                     "funder_ror": entry.get("funder_ror", ""),
+                    "sdg_names": sorted(entry.get("sdg_names", set())),
+                    "country_codes": sorted(entry.get("country_codes", set())),
+                    "institution_names": sorted(
+                        entry.get("institution_names", set())
+                    ),
+                    "document_types": sorted(entry.get("document_types", set())),
+                    "document_languages": sorted(
+                        entry.get("document_languages", set())
+                    ),
+                    "open_access_values": sorted(
+                        entry.get("open_access_values", set())
+                    ),
+                    "open_access_statuses": sorted(
+                        entry.get("open_access_statuses", set())
+                    ),
                 }
             )
             yield action

--- a/search_gateway/lookup/builders/institution.py
+++ b/search_gateway/lookup/builders/institution.py
@@ -13,7 +13,14 @@ class InstitutionLookupBuilder(LookupBuilder):
         "authorships.institutions.ror",
         "authorships.institutions.type",
         "authorships.institutions.country_code",
+        "funders.id",
+        "is_open_access",
+        "language",
+        "open_access_status",
+        "sdg_names",
+        "type",
     ]
+
     @property
     def mapping(self) -> dict[str, Any]:
         return self.build_mapping(
@@ -22,11 +29,23 @@ class InstitutionLookupBuilder(LookupBuilder):
                 "institution_ror": {"type": "keyword"},
                 "institution_types": {"type": "keyword"},
                 "country_codes": {"type": "keyword"},
+                "sdg_names": {"type": "keyword"},
+                "funder_ids": {"type": "keyword"},
+                "document_types": {"type": "keyword"},
+                "document_languages": {"type": "keyword"},
+                "open_access_values": {"type": "keyword"},
+                "open_access_statuses": {"type": "keyword"},
             }
         )
 
     def collect(self, source: dict[str, Any], max_items: int | None = None) -> None:
         seen_values: set[str] = set()
+        sdg_names = set(self.iter_clean_values(source.get("sdg_names")))
+        funder_ids = set()
+        document_metadata = self.collect_document_metadata(source)
+
+        for funder in self.iter_objects(source.get("funders")):
+            funder_ids.update(self.iter_clean_values(funder.get("id")))
 
         for authorship in self.iter_objects(source.get("authorships")):
             for institution in self.iter_objects(authorship.get("institutions")):
@@ -47,6 +66,10 @@ class InstitutionLookupBuilder(LookupBuilder):
                 entry.setdefault("country_codes", set()).update(
                     self.iter_clean_values(institution.get("country_code"))
                 )
+                entry.setdefault("sdg_names", set()).update(sdg_names)
+                entry.setdefault("funder_ids", set()).update(funder_ids)
+                for field_name, values in document_metadata.items():
+                    entry.setdefault(field_name, set()).update(values)
 
     def iter_actions(self, index_name: str) -> Iterable[dict[str, Any]]:
         for action in super().iter_actions(index_name):
@@ -57,6 +80,18 @@ class InstitutionLookupBuilder(LookupBuilder):
                     "institution_ror": entry.get("institution_ror", ""),
                     "institution_types": sorted(entry.get("institution_types", set())),
                     "country_codes": sorted(entry.get("country_codes", set())),
+                    "sdg_names": sorted(entry.get("sdg_names", set())),
+                    "funder_ids": sorted(entry.get("funder_ids", set())),
+                    "document_types": sorted(entry.get("document_types", set())),
+                    "document_languages": sorted(
+                        entry.get("document_languages", set())
+                    ),
+                    "open_access_values": sorted(
+                        entry.get("open_access_values", set())
+                    ),
+                    "open_access_statuses": sorted(
+                        entry.get("open_access_statuses", set())
+                    ),
                 }
             )
             yield action

--- a/search_gateway/lookup/builders/publisher.py
+++ b/search_gateway/lookup/builders/publisher.py
@@ -1,37 +1,138 @@
 from collections.abc import Iterable
 from typing import Any
 
+from django.conf import settings
+
 from search_gateway.lookup.base import LookupBuilder, clean_text
 
 
 class PublisherLookupBuilder(LookupBuilder):
     key = "publisher"
     default_index_name = "silver_lookup_publisher"
-    source_fields = ["source.type", "publishers.name", "publishers.id"]
+    source_fields = [
+        "indexed_in",
+        "is_open_access",
+        "language",
+        "oca_data.scielo.collection",
+        "oca_data.scielo.source.country_code",
+        "oca_data.scielo.source.indexed_in",
+        "open_access_status",
+        "source.title",
+        "source.type",
+        "type",
+        "publishers.name",
+        "publishers.id",
+    ]
+
     @property
     def mapping(self) -> dict[str, Any]:
-        return self.build_mapping({"publisher_id": {"type": "keyword"}})
+        return self.build_mapping(
+            {
+                "publisher_id": {"type": "keyword"},
+                "source_names": {"type": "keyword"},
+                "source_types": {"type": "keyword"},
+                "source_country_codes": {"type": "keyword"},
+                "indexed_in": {"type": "keyword"},
+                "source_scielo_indexed_in": {"type": "keyword"},
+                "collections": {"type": "keyword"},
+                "document_types": {"type": "keyword"},
+                "document_languages": {"type": "keyword"},
+                "open_access_values": {"type": "keyword"},
+                "open_access_statuses": {"type": "keyword"},
+            }
+        )
+
+    @classmethod
+    def allowed_source_types(cls):
+        allowed_types = set()
+
+        for source_type in settings.SEARCH_GATEWAY_LOOKUP_SOURCE_TYPES:
+            cleaned = clean_text(source_type)
+            if cleaned:
+                allowed_types.add(cleaned.lower())
+
+        return allowed_types
 
     def collect(self, source: dict[str, Any], max_items: int | None = None) -> None:
-        if not any(
-            clean_text(src.get("type")).lower() == "journal"
-            for src in self.iter_objects(source.get("source"))
-        ):
+        allowed_source_types = self.allowed_source_types()
+        source_names = set()
+        source_types = set()
+        oca_data = source.get("oca_data") or {}
+        scielo = oca_data.get("scielo") or {}
+        scielo_source = scielo.get("source") or {}
+        source_country_codes = set(
+            self.iter_clean_values(scielo_source.get("country_code"))
+        )
+        indexed_in = set(self.iter_clean_values(source.get("indexed_in")))
+        source_scielo_indexed_in = set(
+            self.iter_clean_values(scielo_source.get("indexed_in"))
+        )
+        collections = set(self.iter_clean_values(scielo.get("collection")))
+        document_metadata = self.collect_document_metadata(source)
+
+        for src in self.iter_objects(source.get("source")):
+            source_type = clean_text(src.get("type"))
+            if source_type.lower() not in allowed_source_types:
+                continue
+            source_types.add(source_type)
+
+            title = clean_text(src.get("title"))
+            if title:
+                source_names.add(title)
+
+        if not source_types:
             return
 
         seen_values: set[str] = set()
 
         for publisher in self.iter_objects(source.get("publishers")):
-            self.add_entry(
+            entry = self.add_entry(
                 clean_text(publisher.get("name")),
                 clean_text(publisher.get("name")),
                 seen_values,
                 max_items,
                 publisher_id=clean_text(publisher.get("id")),
             )
+            if entry:
+                entry.setdefault("source_names", set()).update(source_names)
+                entry.setdefault("source_types", set()).update(source_types)
+                entry.setdefault("source_country_codes", set()).update(
+                    source_country_codes
+                )
+                entry.setdefault("indexed_in", set()).update(indexed_in)
+                entry.setdefault("source_scielo_indexed_in", set()).update(
+                    source_scielo_indexed_in
+                )
+                entry.setdefault("collections", set()).update(collections)
+                for field_name, values in document_metadata.items():
+                    entry.setdefault(field_name, set()).update(values)
 
     def iter_actions(self, index_name: str) -> Iterable[dict[str, Any]]:
         for action in super().iter_actions(index_name):
             entry = self.entries[action["_source"]["value"]]
-            action["_source"].update({"publisher_id": entry.get("publisher_id", "")})
+            action["_source"].update(
+                {
+                    "publisher_id": entry.get("publisher_id", ""),
+                    "source_names": sorted(entry.get("source_names", set())),
+                    "source_types": sorted(entry.get("source_types", set())),
+                    "source_country_codes": sorted(
+                        entry.get("source_country_codes", set())
+                    ),
+                    "indexed_in": sorted(entry.get("indexed_in", set())),
+                    "source_scielo_indexed_in": sorted(
+                        entry.get("source_scielo_indexed_in", set())
+                    ),
+                    "collections": sorted(entry.get("collections", set())),
+                    "document_types": sorted(entry.get("document_types", set())),
+                    "document_languages": sorted(
+                        entry.get("document_languages", set())
+                    ),
+                    "open_access_values": sorted(
+                        entry.get("open_access_values", set())
+                    ),
+                    "open_access_statuses": sorted(
+                        entry.get("open_access_statuses", set())
+                    ),
+                }
+            )
             yield action

--- a/search_gateway/lookup/builders/source.py
+++ b/search_gateway/lookup/builders/source.py
@@ -1,6 +1,8 @@
 from collections.abc import Iterable
 from typing import Any
 
+from django.conf import settings
+
 from search_gateway.lookup.base import LookupBuilder, clean_text
 
 
@@ -24,6 +26,17 @@ class SourceLookupBuilder(LookupBuilder):
                 "publisher_ids": {"type": "keyword"},
             }
         )
+
+    @classmethod
+    def allowed_source_types(cls):
+        allowed_types = set()
+
+        for source_type in settings.SEARCH_GATEWAY_LOOKUP_SOURCE_TYPES:
+            cleaned = clean_text(source_type)
+            if cleaned:
+                allowed_types.add(cleaned.lower())
+
+        return allowed_types
 
     def collect(self, source: dict[str, Any], max_items: int | None = None) -> None:
         seen_values: set[str] = set()

--- a/search_gateway/lookup/builders/source.py
+++ b/search_gateway/lookup/builders/source.py
@@ -10,12 +10,22 @@ class SourceLookupBuilder(LookupBuilder):
     key = "source"
     default_index_name = "silver_lookup_source"
     source_fields = [
+        "indexed_in",
+        "is_open_access",
+        "language",
+        "oca_data.scielo.collection",
+        "oca_data.scielo.source.country_code",
+        "oca_data.scielo.source.indexed_in",
+        "open_access_status",
         "source.title",
         "source.ids.openalex",
         "source.type",
         "source.issn_l",
+        "type",
         "publishers.id",
+        "publishers.name",
     ]
+
     @property
     def mapping(self) -> dict[str, Any]:
         return self.build_mapping(
@@ -24,6 +34,15 @@ class SourceLookupBuilder(LookupBuilder):
                 "source_type": {"type": "keyword"},
                 "source_issn_l": {"type": "keyword"},
                 "publisher_ids": {"type": "keyword"},
+                "publisher_names": {"type": "keyword"},
+                "source_country_codes": {"type": "keyword"},
+                "indexed_in": {"type": "keyword"},
+                "source_scielo_indexed_in": {"type": "keyword"},
+                "collections": {"type": "keyword"},
+                "document_types": {"type": "keyword"},
+                "document_languages": {"type": "keyword"},
+                "open_access_values": {"type": "keyword"},
+                "open_access_statuses": {"type": "keyword"},
             }
         )
 
@@ -41,31 +60,58 @@ class SourceLookupBuilder(LookupBuilder):
     def collect(self, source: dict[str, Any], max_items: int | None = None) -> None:
         seen_values: set[str] = set()
         publisher_ids = set()
+        publisher_names = set()
+        allowed_source_types = self.allowed_source_types()
+        oca_data = source.get("oca_data") or {}
+        scielo = oca_data.get("scielo") or {}
+        scielo_source = scielo.get("source") or {}
+        source_country_codes = set(
+            self.iter_clean_values(scielo_source.get("country_code"))
+        )
+        indexed_in = set(self.iter_clean_values(source.get("indexed_in")))
+        source_scielo_indexed_in = set(
+            self.iter_clean_values(scielo_source.get("indexed_in"))
+        )
+        collections = set(self.iter_clean_values(scielo.get("collection")))
+        document_metadata = self.collect_document_metadata(source)
 
         for publisher in self.iter_objects(source.get("publishers")):
             publisher_ids.update(self.iter_clean_values(publisher.get("id")))
+            publisher_names.update(self.iter_clean_values(publisher.get("name")))
 
         for src in self.iter_objects(source.get("source")):
-            source_id = clean_text((src.get("ids") or {}).get("openalex"))
-            if not source_id:
+            source_type = clean_text(src.get("type"))
+            if source_type.lower() not in allowed_source_types:
                 continue
 
             title = clean_text(src.get("title"))
             if not title:
                 continue
 
+            source_id = clean_text((src.get("ids") or {}).get("openalex"))
             entry = self.add_entry(
-                source_id,
-                title,
-                seen_values,
-                max_items,
+                value=title,
+                label=title,
+                seen_values=seen_values,
+                max_items=max_items,
                 source_id=source_id,
-                source_type=clean_text(src.get("type")),
+                source_type=source_type,
                 source_issn_l=clean_text(src.get("issn_l")),
             )
 
             if entry:
                 entry.setdefault("publisher_ids", set()).update(publisher_ids)
+                entry.setdefault("publisher_names", set()).update(publisher_names)
+                entry.setdefault("source_country_codes", set()).update(
+                    source_country_codes
+                )
+                entry.setdefault("indexed_in", set()).update(indexed_in)
+                entry.setdefault("source_scielo_indexed_in", set()).update(
+                    source_scielo_indexed_in
+                )
+                entry.setdefault("collections", set()).update(collections)
+                for field_name, values in document_metadata.items():
+                    entry.setdefault(field_name, set()).update(values)
 
     def iter_actions(self, index_name: str) -> Iterable[dict[str, Any]]:
         for action in super().iter_actions(index_name):
@@ -76,6 +122,25 @@ class SourceLookupBuilder(LookupBuilder):
                     "source_type": entry.get("source_type", ""),
                     "source_issn_l": entry.get("source_issn_l", ""),
                     "publisher_ids": sorted(entry.get("publisher_ids", set())),
+                    "publisher_names": sorted(entry.get("publisher_names", set())),
+                    "source_country_codes": sorted(
+                        entry.get("source_country_codes", set())
+                    ),
+                    "indexed_in": sorted(entry.get("indexed_in", set())),
+                    "source_scielo_indexed_in": sorted(
+                        entry.get("source_scielo_indexed_in", set())
+                    ),
+                    "collections": sorted(entry.get("collections", set())),
+                    "document_types": sorted(entry.get("document_types", set())),
+                    "document_languages": sorted(
+                        entry.get("document_languages", set())
+                    ),
+                    "open_access_values": sorted(
+                        entry.get("open_access_values", set())
+                    ),
+                    "open_access_statuses": sorted(
+                        entry.get("open_access_statuses", set())
+                    ),
                 }
             )
             yield action

--- a/search_gateway/management/commands/build_lookup_indices.py
+++ b/search_gateway/management/commands/build_lookup_indices.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         default_source_index = getattr(
             settings,
             "SEARCH_GATEWAY_LOOKUP_SOURCE_INDEX",
-            getattr(settings, "OP_INDEX_SCIENTIFIC_PRODUCTION", "scientific_production"),
+            getattr(settings, "OP_INDEX_SCIENTIFIC_PRODUCTION", "silver_scientific_production"),
         )
         default_batch_size = getattr(settings, "SEARCH_GATEWAY_LOOKUP_BATCH_SIZE", 500)
         parser.add_argument(

--- a/search_gateway/option_normalization.py
+++ b/search_gateway/option_normalization.py
@@ -97,10 +97,13 @@ def normalize_selected_values(applied_filters, field_name, default=None):
 # ---------------------------------------------------------------------------
 
 def normalize_option(option, selected_values):
+    option_count = None
+
     if isinstance(option, dict):
         value = option.get("value", option.get("key", option.get("id")))
         label = option.get("label", option.get("text", value))
         group = option.get("group")
+        option_count = option.get("option_count", option.get("size", option.get("doc_count")))
     else:
         value = option
         label = option
@@ -110,12 +113,17 @@ def normalize_option(option, selected_values):
     normalized_label = gettext(label) if isinstance(label, str) and label else label
     normalized_group = gettext(group) if isinstance(group, str) and group else group
 
-    return {
+    normalized = {
         "value": normalized_value,
         "label": normalized_label or normalized_value,
         "group": normalized_group,
         "selected": normalized_value in selected_values,
     }
+
+    if option_count is not None:
+        normalized["option_count"] = option_count
+
+    return normalized
 
 
 def normalize_options(options, selected_values):

--- a/search_gateway/service.py
+++ b/search_gateway/service.py
@@ -184,20 +184,42 @@ class SearchGatewayService:
             if field_info.get("kind") != "control"
         }
 
-    def _search_lookup_options(self, field, query_text=""):
+    @staticmethod
+    def _build_lookup_dependency_filters(lookup_config, filters):
+        dependency_filters = lookup_config.get("dependency_filters") or {}
+        if not dependency_filters or not filters:
+            return {}
+
+        lookup_filters = {}
+        for filter_name, lookup_field_name in dependency_filters.items():
+            value = filters.get(filter_name)
+            if value in (None, "", []):
+                continue
+
+            lookup_filters[lookup_field_name] = value if isinstance(value, list) else [value]
+
+        return lookup_filters
+
+    def _search_lookup_options(self, field, query_text="", filters=None):
         lookup_config = field.lookup
         source_fields = [
             lookup_config["source_value_field"],
             lookup_config["source_label_field"],
             "size",
         ]
+
+        lookup_filters = dict(lookup_config.get("filter") or {})
+        lookup_filters.update(
+            self._build_lookup_dependency_filters(lookup_config, filters or {})
+        )
+
         body = build_lookup_hits_body(
             query_text=query_text,
             search_fields=[lookup_config["search_field"]],
             size=field.get_option_limit(default=100),
             source_fields=source_fields,
             sort_field=lookup_config["sort_field"],
-            filters=lookup_config.get("filter"),
+            filters=lookup_filters,
         )
         response = self.client.search(
             index=lookup_config["index_name"],
@@ -249,7 +271,7 @@ class SearchGatewayService:
 
         if field.lookup:
             try:
-                return self._search_lookup_options(field, query_text=query_text)
+                return self._search_lookup_options(field, query_text=query_text, filters=filters)
             except Exception as exc:
                 return [], f"Error retrieving lookup options: {exc}"
 

--- a/search_gateway/settings.py
+++ b/search_gateway/settings.py
@@ -33,6 +33,10 @@ SEARCH_GATEWAY_LOOKUP_NUMBER_OF_REPLICAS = _env.int(
     "SEARCH_GATEWAY_LOOKUP_NUMBER_OF_REPLICAS",
     default=0,
 )
+SEARCH_GATEWAY_LOOKUP_SOURCE_TYPES = _env.list(
+    "SEARCH_GATEWAY_LOOKUP_SOURCE_TYPES",
+    default=["journal", "conference"],
+)
 SEARCH_GATEWAY_ERROR_INDEX = _env.str(
     "SEARCH_GATEWAY_ERROR_INDEX",
     default="search_gateway_errors",

--- a/search_gateway/static/search_gateway/css/filter_sidebar.css
+++ b/search_gateway/static/search_gateway/css/filter_sidebar.css
@@ -555,6 +555,22 @@
   line-height: 1.4;
 }
 
+.lookup-checkbox-field__label,
+.checkbox-field__label {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.lookup-checkbox-field__count,
+.checkbox-field__count {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--sg-text-muted);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.4;
+}
+
 .lookup-checkbox-field__item input,
 .checkbox-field__item input {
   margin-top: 0.2rem;

--- a/search_gateway/static/search_gateway/js/filter_form.js
+++ b/search_gateway/static/search_gateway/js/filter_form.js
@@ -222,10 +222,15 @@
     (list || []).forEach(option => {
       const value = String(option?.value ?? option?.key ?? option?.id ?? '').trim();
       if (!value || seen.has(value)) return;
-      normalized.push({
+      const optionCount = option?.option_count ?? option?.size ?? option?.doc_count;
+      const normalizedOption = {
         value,
         label: String(option?.label ?? option?.text ?? value).trim(),
-      });
+      };
+      if (optionCount !== null && optionCount !== undefined && optionCount !== '') {
+        normalizedOption.option_count = optionCount;
+      }
+      normalized.push(normalizedOption);
       seen.add(value);
     });
 
@@ -256,7 +261,11 @@
     (initialOptions || []).forEach(item => {
       const value = String(item?.value || '').trim();
       if (!value || !item.checked || baseValues.has(value)) return;
-      pinned.set(value, { value, label: String(item.label || value) });
+      const pinnedOption = { value, label: String(item.label || value) };
+      if (item.option_count !== null && item.option_count !== undefined && item.option_count !== '') {
+        pinnedOption.option_count = item.option_count;
+      }
+      pinned.set(value, pinnedOption);
     });
 
     return {
@@ -346,13 +355,19 @@
     return Array.from(optionsContainer.querySelectorAll(selector))
       .map(input => {
         const value = String(input.value || '').trim();
-        const label = String(input.closest('label')?.querySelector('span')?.textContent || value).trim();
+        const label = String(
+          input.closest('label')?.querySelector('.lookup-checkbox-field__label, .checkbox-field__label')?.textContent
+          || input.closest('label')?.querySelector('span')?.textContent
+          || value
+        ).trim();
         const isAllOption = String(input.dataset.allOption || '').toLowerCase() === 'true';
+        const optionCount = input.dataset.optionCount;
         return {
           value,
           label,
           checked: !!input.checked,
           isAllOption,
+          option_count: optionCount,
         };
       })
       .filter(item => item.value || item.isAllOption);
@@ -377,11 +392,23 @@
     inputElement.checked = !!checked;
 
     const textElement = document.createElement('span');
+    textElement.className = itemClass === 'lookup-checkbox-field__item'
+      ? 'lookup-checkbox-field__label'
+      : 'checkbox-field__label';
     textElement.textContent = option.label;
 
     labelElement.setAttribute('for', inputElement.id);
     labelElement.appendChild(inputElement);
     labelElement.appendChild(textElement);
+    if (option.option_count !== null && option.option_count !== undefined && option.option_count !== '') {
+      inputElement.dataset.optionCount = option.option_count;
+      const countElement = document.createElement('span');
+      countElement.className = itemClass === 'lookup-checkbox-field__item'
+        ? 'lookup-checkbox-field__count'
+        : 'checkbox-field__count';
+      countElement.textContent = option.option_count;
+      labelElement.appendChild(countElement);
+    }
     return labelElement;
   }
 

--- a/search_gateway/templates/search_gateway/forms/widgets/checkbox_multi.html
+++ b/search_gateway/templates/search_gateway/forms/widgets/checkbox_multi.html
@@ -46,9 +46,13 @@
             data-field-name="{{ field.name }}"
             data-field-widget="checkbox"
             data-multiple-selection="true"
+            {% if option.option_count is not None %}data-option-count="{{ option.option_count }}"{% endif %}
             {% if option.selected %}checked{% endif %}
           />
-          <span>{{ option.label }}</span>
+          <span class="checkbox-field__label">{{ option.label }}</span>
+          {% if option.option_count is not None %}
+            <span class="checkbox-field__count">{{ option.option_count }}</span>
+          {% endif %}
         </label>
       {% endfor %}
     {% endfor %}

--- a/search_gateway/templates/search_gateway/forms/widgets/lookup.html
+++ b/search_gateway/templates/search_gateway/forms/widgets/lookup.html
@@ -49,9 +49,13 @@
             data-field-name="{{ field.name }}"
             data-field-widget="checkbox"
             data-multiple-selection="{{ field.multiple_selection|yesno:'true,false' }}"
+            {% if option.option_count is not None %}data-option-count="{{ option.option_count }}"{% endif %}
             {% if option.selected %}checked{% endif %}
           />
-          <span>{{ option.label }}</span>
+          <span class="lookup-checkbox-field__label">{{ option.label }}</span>
+          {% if option.option_count is not None %}
+            <span class="lookup-checkbox-field__count">{{ option.option_count }}</span>
+          {% endif %}
         </label>
       {% endfor %}
     {% endfor %}

--- a/search_gateway/tests/lookup/test_main_lookup.py
+++ b/search_gateway/tests/lookup/test_main_lookup.py
@@ -5,6 +5,7 @@ from django.core.management.base import CommandError
 from django.test import SimpleTestCase, override_settings
 
 from search_gateway.lookup import (
+    FunderLookupBuilder,
     LOOKUP_BUILDERS,
     InstitutionLookupBuilder,
     LookupBuilder,
@@ -28,7 +29,21 @@ class LookupBuilderTests(SimpleTestCase):
     def test_publisher_accepts_missing_id_and_counts_once_per_document(self):
         builder = PublisherLookupBuilder()
         source = {
+            "indexed_in": ["doaj"],
+            "is_open_access": True,
+            "language": "pt",
+            "oca_data": {
+                "scielo": {
+                    "collection": "scl",
+                    "source": {
+                        "country_code": "BR",
+                        "indexed_in": ["scielo"],
+                    },
+                }
+            },
+            "open_access_status": "gold",
             "source": [{"type": "journal"}],
+            "type": "research-article",
             "publishers": [
                 {"name": "SciELO"},
                 {"name": "SciELO"},
@@ -43,6 +58,15 @@ class LookupBuilderTests(SimpleTestCase):
         self.assertEqual(len(actions), 1)
         self.assertEqual(actions[0]["_source"]["value"], "SciELO")
         self.assertEqual(actions[0]["_source"]["label"], "SciELO")
+        self.assertEqual(actions[0]["_source"]["source_types"], ["journal"])
+        self.assertEqual(actions[0]["_source"]["source_country_codes"], ["BR"])
+        self.assertEqual(actions[0]["_source"]["indexed_in"], ["doaj"])
+        self.assertEqual(actions[0]["_source"]["source_scielo_indexed_in"], ["scielo"])
+        self.assertEqual(actions[0]["_source"]["collections"], ["scl"])
+        self.assertEqual(actions[0]["_source"]["document_types"], ["research-article"])
+        self.assertEqual(actions[0]["_source"]["document_languages"], ["pt"])
+        self.assertEqual(actions[0]["_source"]["open_access_values"], ["true"])
+        self.assertEqual(actions[0]["_source"]["open_access_statuses"], ["gold"])
         self.assertEqual(actions[0]["_source"]["size"], 2)
 
     def test_publisher_uses_name_as_value_even_when_id_exists(self):
@@ -58,11 +82,18 @@ class LookupBuilderTests(SimpleTestCase):
 
         self.assertEqual(action["_source"]["value"], "Elsevier BV")
         self.assertEqual(action["_source"]["publisher_id"], "https://openalex.org/P1")
+        self.assertEqual(action["_source"]["source_types"], ["journal"])
 
     def test_institution_accepts_missing_id_and_sources_object_shape(self):
         builder = InstitutionLookupBuilder()
         builder.collect(
             {
+                "funders": [{"id": "https://openalex.org/F1"}],
+                "is_open_access": False,
+                "language": "en",
+                "open_access_status": "closed",
+                "sdg_names": ["Good Health and Well-being"],
+                "type": "review",
                 "authorships": [
                     {
                         "institutions": [
@@ -79,6 +110,15 @@ class LookupBuilderTests(SimpleTestCase):
         self.assertEqual(len(actions), 1)
         self.assertEqual(actions[0]["_source"]["value"], "Universidade de Sao Paulo")
         self.assertEqual(actions[0]["_source"]["country_codes"], ["BR"])
+        self.assertEqual(
+            actions[0]["_source"]["sdg_names"],
+            ["Good Health and Well-being"],
+        )
+        self.assertEqual(actions[0]["_source"]["funder_ids"], ["https://openalex.org/F1"])
+        self.assertEqual(actions[0]["_source"]["document_types"], ["review"])
+        self.assertEqual(actions[0]["_source"]["document_languages"], ["en"])
+        self.assertEqual(actions[0]["_source"]["open_access_values"], ["false"])
+        self.assertEqual(actions[0]["_source"]["open_access_statuses"], ["closed"])
         self.assertEqual(actions[0]["_source"]["size"], 1)
 
     def test_institution_uses_name_as_value_even_when_id_exists(self):
@@ -102,15 +142,108 @@ class LookupBuilderTests(SimpleTestCase):
 
     def test_source_accepts_sources_as_list_or_object(self):
         builder = SourceLookupBuilder()
-        builder.collect({"source": {"ids": {"openalex": "j1"}, "title": "Journal One", "type": "journal"}})
-        builder.collect({"source": [{"ids": {"openalex": "j1"}, "title": "Journal One", "type": "journal"}]})
+        builder.collect(
+            {
+                "indexed_in": ["doaj"],
+                "is_open_access": True,
+                "language": "pt",
+                "oca_data": {
+                    "scielo": {
+                        "collection": "scl",
+                        "source": {
+                            "country_code": "BR",
+                            "indexed_in": ["scielo"],
+                        },
+                    }
+                },
+                "open_access_status": "gold",
+                "source": {
+                    "ids": {"openalex": "j1"},
+                    "title": "Journal One",
+                    "type": "journal",
+                },
+                "publishers": [
+                    {
+                        "id": "https://openalex.org/P1",
+                        "name": "SciELO",
+                    }
+                ],
+                "type": "research-article",
+            }
+        )
+        builder.collect(
+            {
+                "source": [
+                    {
+                        "ids": {"openalex": "j1"},
+                        "title": "Journal One",
+                        "type": "journal",
+                    }
+                ]
+            }
+        )
 
         actions = list(builder.iter_actions("lookup_source"))
 
         self.assertEqual(len(actions), 1)
-        self.assertEqual(actions[0]["_source"]["value"], "j1")
+        self.assertEqual(actions[0]["_source"]["value"], "Journal One")
         self.assertEqual(actions[0]["_source"]["label"], "Journal One")
+        self.assertEqual(actions[0]["_source"]["source_id"], "j1")
+        self.assertEqual(actions[0]["_source"]["publisher_ids"], ["https://openalex.org/P1"])
+        self.assertEqual(actions[0]["_source"]["publisher_names"], ["SciELO"])
+        self.assertEqual(actions[0]["_source"]["source_country_codes"], ["BR"])
+        self.assertEqual(actions[0]["_source"]["indexed_in"], ["doaj"])
+        self.assertEqual(actions[0]["_source"]["source_scielo_indexed_in"], ["scielo"])
+        self.assertEqual(actions[0]["_source"]["collections"], ["scl"])
+        self.assertEqual(actions[0]["_source"]["document_types"], ["research-article"])
+        self.assertEqual(actions[0]["_source"]["document_languages"], ["pt"])
+        self.assertEqual(actions[0]["_source"]["open_access_values"], ["true"])
+        self.assertEqual(actions[0]["_source"]["open_access_statuses"], ["gold"])
         self.assertEqual(actions[0]["_source"]["size"], 2)
+
+    def test_funder_collects_dependency_metadata(self):
+        builder = FunderLookupBuilder()
+        builder.collect(
+            {
+                "author_country_codes": ["BR"],
+                "funders": [
+                    {
+                        "id": "https://openalex.org/F1",
+                        "name": "Fundacao de Amparo",
+                        "ror": "https://ror.org/01",
+                    },
+                    {
+                        "id": "https://openalex.org/F1",
+                        "name": "Fundacao de Amparo",
+                    },
+                ],
+                "institutions": ["Universidade de Sao Paulo"],
+                "is_open_access": True,
+                "language": "pt",
+                "open_access_status": "gold",
+                "sdg_names": ["Good Health and Well-being"],
+                "type": "research-article",
+            }
+        )
+
+        actions = list(builder.iter_actions("lookup_funder"))
+
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0]["_source"]["value"], "https://openalex.org/F1")
+        self.assertEqual(actions[0]["_source"]["label"], "Fundacao de Amparo")
+        self.assertEqual(actions[0]["_source"]["country_codes"], ["BR"])
+        self.assertEqual(
+            actions[0]["_source"]["institution_names"],
+            ["Universidade de Sao Paulo"],
+        )
+        self.assertEqual(
+            actions[0]["_source"]["sdg_names"],
+            ["Good Health and Well-being"],
+        )
+        self.assertEqual(actions[0]["_source"]["document_types"], ["research-article"])
+        self.assertEqual(actions[0]["_source"]["document_languages"], ["pt"])
+        self.assertEqual(actions[0]["_source"]["open_access_values"], ["true"])
+        self.assertEqual(actions[0]["_source"]["open_access_statuses"], ["gold"])
 
 
 class LookupQueryTests(SimpleTestCase):

--- a/search_gateway/tests/lookup/test_normalize_text.py
+++ b/search_gateway/tests/lookup/test_normalize_text.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from search_gateway.option_normalization import clean_text, normalize_text
+from search_gateway.option_normalization import clean_text, normalize_options, normalize_text
 
 
 class NormalizeTextTests(SimpleTestCase):
@@ -71,3 +71,15 @@ class NormalizeTextTests(SimpleTestCase):
                 # Normalized should preserve case
                 if any(c.isupper() for c in text):
                     self.assertTrue(any(c.isupper() for c in normalized))
+
+    def test_normalize_options_preserves_counts(self):
+        options = normalize_options(
+            [
+                {"value": "journal", "label": "Journal", "doc_count": 12},
+                {"value": "SciELO", "label": "SciELO", "size": 34},
+            ],
+            selected_values=[],
+        )
+
+        self.assertEqual(options[0]["option_count"], 12)
+        self.assertEqual(options[1]["option_count"], 34)

--- a/search_gateway/transforms.py
+++ b/search_gateway/transforms.py
@@ -135,7 +135,9 @@ def _get_source_type_display(value):
         "ebook platform": _("eBook platform"),
         "igsncatalog": _("IGSN Catalog"),
         "journal": _("Journal"),
+        "metadata": _("Metadata"),
         "other": _("Other"),
+        "raidregistry": _("RAID Registry"),
         "repository": _("Repository"),
     }.get(clean_text(value).lower(), value)
 


### PR DESCRIPTION
#### O que esse PR faz?

A tarefa iniciou tratando o builder do lookup de source, que apresentava nomes relacionados a publishers entre os valores gerados. Como solução, passou a ser possível definir quais campos são úteis para popular os valores do lookup de source. Por padrão, entende-se que devem ser considerados apenas sources dos tipos `journal` e `conference`.

Como essa história está diretamente ligada ao reprocessamento dos lookups, optou-se também por implementar melhorias no dinamismo desses seletores. O sistema já possuía algum dinamismo entre campos diferentes de lookup, mas ainda não havia cruzamento entre campos lookup e campos não lookup. Por isso, os dados gerados pelos builders de lookup foram enriquecidos, permitindo aplicar esse dinamismo também nesse cenário.

Por fim, aproveitou-se a alteração para incorporar o N associado a cada faceta, permitindo que as opções exibidas nos filtros indiquem também a quantidade de documentos relacionada a cada valor. O PR também atualiza as fixtures básicas e os testes correspondentes.

#### Onde a revisão poderia começar?

1. `search_gateway/lookup/base.py` — utilitários (`collect_document_metadata`, `clean_boolean_value`, `iter_clean_boolean_values`) e o serviço de build.
2. `search_gateway/lookup/builders/{source,publisher,funder,institution}.py` — enriquecimento dos lookups.
3. `search_gateway/service.py` — `_build_lookup_dependency_filters` e o `_search_lookup_options` recebendo `filters` (dinamismo).
4. `search_gateway/option_normalization.py` — `normalize_option` buscando o campo de contagem.
5. Front: `search_gateway/templates/.../widgets/{checkbox_multi,lookup}.html`, `static/.../js/filter_form.js`, `static/.../css/filter_sidebar.css`.
6. `search_gateway/fixtures/datasources.json` — configuração de `dependency_filters` por campo.

#### Como este poderia ser testado manualmente?

1. Garanta que o índice fonte `silver_scientific_production` esteja populado no OpenSearch.
2. (Opcional) ajuste `SEARCH_GATEWAY_LOOKUP_SOURCE_TYPES` (default: `journal,conference`) conforme o cenário.
3. (Re)construa os índices de lookup: `python manage.py build_lookup_indices` (use `--lookup-index KEY=INDEX` ou apague os índices existentes, pois o comando não sobrescreve índices já criados).
4. Carregue as fixtures: `python manage.py loaddata search_gateway/fixtures/datasources.json core/fixtures/pages.json`.
5. Abra a tela de busca e verifique que cada opção de filtro mostra o N (contagem) ao lado do rótulo.
6. Aplique um filtro (ex.: idioma, open access, país ou tipo de source) e confirme que as opções dos filtros de lookup (sources, publishers, etc.) se restringem dinamicamente e que os N's refletem o novo contexto.

### Screenshots
_Tela que mostra o número de registros representando um campo no filtro_
<img width="1067" height="951" alt="image" src="https://github.com/user-attachments/assets/aa8a4b06-4d54-4815-9846-fb447c551543" />

#### Quais são tickets relevantes?
#717 e #711 

### Referências
N/A
