### PR TITLE
Acrescenta loading em tela de indicadores

### DIFF
--- a/indicator/static/indicator/css/custom.css
+++ b/indicator/static/indicator/css/custom.css
@@ -692,3 +692,62 @@ body.modal-open .indicator-filters-toggle {
   font-size: 0.92rem;
   color: #667085;
 }
+
+.search-loading-spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: search-loading-spin 0.75s linear infinite;
+  flex: 0 0 auto;
+}
+
+.search-loading-spinner--large {
+  width: 2.35rem;
+  height: 2.35rem;
+  border-width: 3px;
+  color: #2f4ea1;
+}
+
+@keyframes search-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.indicator-results-col--loading {
+  position: relative;
+  min-height: 12rem;
+}
+
+.indicator-results-loading {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.indicator-results-loading[hidden] {
+  display: none;
+}
+
+.indicator-results-loading-inner {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.indicator-results-loading-text {
+  color: #60799a;
+  font-size: 0.95rem;
+  font-weight: 600;
+}

--- a/indicator/static/indicator/js/menu.js
+++ b/indicator/static/indicator/js/menu.js
@@ -220,6 +220,74 @@ function initBreakdownVariableAutoSubmit(menuForm, submitButton) {
   breakdownSelect.dataset.autoSubmitBound = 'true';
 }
 
+function getIndicatorResultsCol() {
+  return document.querySelector('.indicator-results-col');
+}
+
+var indicatorLoadingOptions = {
+  overlayClass: 'indicator-results-loading',
+  innerClass: 'indicator-results-loading-inner',
+  textClass: 'indicator-results-loading-text',
+  loadingClass: 'indicator-results-col--loading',
+  message: getLoadingMessage(),
+};
+
+var indicatorLoading = createLoadingOverlay(getIndicatorResultsCol, indicatorLoadingOptions);
+
+function positionIndicatorLoadingOverlay() {
+  var col = indicatorLoading.getContainer();
+
+  if (!col) {
+    return;
+  }
+
+  var overlay = indicatorLoading.getOverlay();
+
+  if (!overlay) {
+    return;
+  }
+
+  var inner = overlay.querySelector('.indicator-results-loading-inner');
+
+  if (!inner) {
+    return;
+  }
+
+  var rect = col.getBoundingClientRect();
+
+  inner.style.left = (rect.left + rect.width / 2) + 'px';
+}
+
+var indicatorLoadingResizeBound = false;
+
+function showIndicatorLoading() {
+  var col = indicatorLoading.getContainer();
+
+  if (!col) {
+    return;
+  }
+
+  indicatorLoading.show();
+
+  positionIndicatorLoadingOverlay();
+
+  if (!indicatorLoadingResizeBound) {
+    window.addEventListener('resize', positionIndicatorLoadingOverlay);
+    indicatorLoadingResizeBound = true;
+  }
+}
+
+function hideIndicatorLoading() {
+  indicatorLoading.hide();
+}
+
+if (typeof window !== 'undefined') {
+  window.IndicatorLoading = {
+    show: showIndicatorLoading,
+    hide: hideIndicatorLoading,
+  };
+}
+
 function initIndicatorForm(dataSource, studyUnit) {
   const menuForm = document.getElementById('indicator-filter-form');
   if (!menuForm) return;
@@ -251,6 +319,7 @@ function initIndicatorForm(dataSource, studyUnit) {
   const handleFormSubmit = (event) => {
     event.preventDefault();
     submitButton.disabled = true;
+    showIndicatorLoading();
 
     const formData = new FormData(menuForm);
     const filters = window.SearchGatewayFilterForm
@@ -326,6 +395,7 @@ function initIndicatorForm(dataSource, studyUnit) {
       clearAppliedFiltersContainer();
     })
     .finally(() => {
+      hideIndicatorLoading();
       submitButton.disabled = false;
     });
   };

--- a/indicator/templates/indicator.html
+++ b/indicator/templates/indicator.html
@@ -38,7 +38,7 @@
   <script src="{% static 'search_gateway/js/helpers.js' %}"></script>
   <script src="{% static 'search_gateway/js/filter_form.js' %}"></script>
   <script src="{% static 'indicator/js/charts.js' %}?v=2"></script>
-  <script src="{% static 'indicator/js/menu.js' %}?v=2"></script>
+  <script src="{% static 'indicator/js/menu.js' %}?v=3"></script>
   <script src="{% static 'indicator/js/layout.js' %}"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/indicator_journal/static/indicator_journal/js/journal_metrics_filters.js
+++ b/indicator_journal/static/indicator_journal/js/journal_metrics_filters.js
@@ -135,6 +135,11 @@
     const params = buildCleanJournalMetricsQueryParams(form);
     const queryString = params.toString();
     const nextUrl = queryString ? `${action}?${queryString}` : action;
+
+    if (window.IndicatorLoading && typeof window.IndicatorLoading.show === 'function') {
+      window.IndicatorLoading.show();
+    }
+
     window.location.assign(nextUrl);
   }
 

--- a/indicator_journal/templates/indicator_journal/indicator_by_category_page.html
+++ b/indicator_journal/templates/indicator_journal/indicator_by_category_page.html
@@ -35,8 +35,8 @@
 {% block inline_javascript %}
   <script src="{% static 'search_gateway/js/helpers.js' %}"></script>
   <script src="{% static 'search_gateway/js/filter_form.js' %}"></script>
-  <script src="{% static 'indicator/js/menu.js' %}?v=2"></script>
+  <script src="{% static 'indicator/js/menu.js' %}?v=3"></script>
   <script src="{% static 'indicator/js/layout.js' %}"></script>
 
-  <script src="{% static 'indicator_journal/js/journal_metrics_filters.js' %}"></script>
+  <script src="{% static 'indicator_journal/js/journal_metrics_filters.js' %}?v=1"></script>
 {% endblock %}

--- a/indicator_journal/templates/indicator_journal/indicator_global_page.html
+++ b/indicator_journal/templates/indicator_journal/indicator_global_page.html
@@ -35,7 +35,7 @@
 {% block inline_javascript %}
   <script src="{% static 'search_gateway/js/helpers.js' %}"></script>
   <script src="{% static 'search_gateway/js/filter_form.js' %}"></script>
-  <script src="{% static 'indicator/js/menu.js' %}?v=2"></script>
+  <script src="{% static 'indicator/js/menu.js' %}?v=3"></script>
   <script src="{% static 'indicator/js/layout.js' %}"></script>
-  <script src="{% static 'indicator_journal/js/journal_metrics_filters.js' %}"></script>
+  <script src="{% static 'indicator_journal/js/journal_metrics_filters.js' %}?v=1"></script>
 {% endblock %}

--- a/search/static/search/js/search_page/results_api.js
+++ b/search/static/search/js/search_page/results_api.js
@@ -8,6 +8,14 @@
     constructor(ctx) {
       this.ctx = ctx;
       this.resultsContainer = document.getElementById('results-container');
+      this._loading = createLoadingOverlay(this.resultsContainer, {
+        overlayClass: 'results-container__loading',
+        innerClass: 'results-container__loading-inner',
+        textClass: 'results-container__loading-text',
+        loadingClass: 'results-container--loading',
+        message: getLoadingMessage(),
+      });
+
       this._filtersFetchAbortController = null;
     }
 
@@ -59,32 +67,6 @@
       return params;
     }
 
-    ensureLoadingOverlay() {
-      if (!this.resultsContainer) return null;
-      let overlay = this.resultsContainer.querySelector('.results-container__loading');
-      if (overlay) return overlay;
-
-      overlay = document.createElement('div');
-      overlay.className = 'results-container__loading';
-      overlay.hidden = true;
-      overlay.setAttribute('role', 'status');
-      overlay.setAttribute('aria-live', 'polite');
-      overlay.innerHTML = `
-        <div class="results-container__loading-inner text-center p-4">
-          <span class="search-loading-spinner search-loading-spinner--large" aria-hidden="true"></span>
-          <p class="results-container__loading-text mb-0 mt-3">${this.getLoadingMessage()}</p>
-        </div>`;
-      this.resultsContainer.appendChild(overlay);
-      return overlay;
-    }
-
-    getLoadingMessage() {
-      if (typeof gettext === 'function') {
-        return gettext('Loading...');
-      }
-      return 'Buscando...';
-    }
-
     toggleSearchSubmitLoading(active) {
       const submitButtons = document.querySelectorAll('#search-form .search-header-card__submit');
       submitButtons.forEach(submitBtn => {
@@ -108,19 +90,11 @@
 
     showLoading() {
       this.toggleSearchSubmitLoading(true);
-      const overlay = this.ensureLoadingOverlay();
-      if (!this.resultsContainer || !overlay) return;
-      this.resultsContainer.classList.add('results-container--loading');
-      this.resultsContainer.setAttribute('aria-busy', 'true');
-      overlay.hidden = false;
+      this._loading.show();
     }
 
     hideLoading() {
-      if (!this.resultsContainer) return;
-      this.resultsContainer.classList.remove('results-container--loading');
-      this.resultsContainer.setAttribute('aria-busy', 'false');
-      const overlay = this.resultsContainer.querySelector('.results-container__loading');
-      if (overlay) overlay.hidden = true;
+      this._loading.hide();
       this.toggleSearchSubmitLoading(false);
     }
 

--- a/search_gateway/static/search_gateway/js/helpers.js
+++ b/search_gateway/static/search_gateway/js/helpers.js
@@ -660,3 +660,87 @@ function standardizeIndicatorSeriesNames(indicators) {
         });
     }
 }
+
+function getLoadingMessage() {
+    if (typeof gettext === 'function') {
+        return gettext('Loading...');
+    }
+    return 'Carregando...';
+}
+
+function createLoadingOverlay(containerOrGetter, options) {
+    var overlayClass = options.overlayClass;
+    var innerClass = options.innerClass;
+    var textClass = options.textClass;
+    var loadingClass = options.loadingClass;
+    var message = options.message;
+
+    var getContainer = typeof containerOrGetter === 'function'
+        ? containerOrGetter
+        : function () { return containerOrGetter; };
+
+    var _overlay = null;
+
+    function ensure() {
+        var container = getContainer();
+
+        if (!container || _overlay) {
+            return _overlay;
+        }
+
+        _overlay = document.createElement('div');
+
+        _overlay.className = overlayClass;
+        _overlay.hidden = true;
+        _overlay.setAttribute('role', 'status');
+        _overlay.setAttribute('aria-live', 'polite');
+
+        _overlay.innerHTML =
+            '<div class="' + innerClass + ' text-center p-4">' +
+                '<span class="search-loading-spinner search-loading-spinner--large" aria-hidden="true"></span>' +
+                '<p class="' + textClass + ' mb-0 mt-3">' + message + '</p>' +
+            '</div>';
+
+        container.appendChild(_overlay);
+
+        return _overlay;
+    }
+
+    function show() {
+        var container = getContainer();
+
+        if (!container) {
+            return;
+        }
+
+        ensure();
+
+        container.classList.add(loadingClass);
+        container.setAttribute('aria-busy', 'true');
+
+        _overlay.hidden = false;
+    }
+
+    function hide() {
+        var container = getContainer();
+
+        if (!container) {
+            return;
+        }
+
+        container.classList.remove(loadingClass);
+        container.setAttribute('aria-busy', 'false');
+
+        if (_overlay) {
+            _overlay.hidden = true;
+        }
+    }
+
+    return {
+        ensure: ensure,
+        show: show,
+        hide: hide,
+        getContainer: getContainer,
+        getOverlay: function () { return _overlay; },
+    };
+}


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona indicador de carregamento (overlay com spinner) na tela de indicadores e nas páginas de métricas de periódicos (journal_*_metrics), seguindo o padrão que já existe na tela de busca. O loading passa a ser exibido nas seguintes ações: a) Clicar em **FILTRAR** na barra de filtros; b) Clicar em **LIMPAR** na barra de filtros; c) Alterar a **variável de detalhamento** (quando a unidade de estudo é *document* ou *source*); d) Alterar a **unidade de estudo** (que recarrega a página); e d) Clicar em **Aplicar** quando estiver em uma página de `journal_*_metrics`.

#### Onde a revisão poderia começar?
Comece por `indicator/static/indicator/js/menu.js`, nos helpers de loading (`showIndicatorLoading` / `hideIndicatorLoading` / `positionIndicatorLoadingOverlay`, expostos via `window.IndicatorLoading`) e em como eles são chamados no `handleFormSubmit` e no handler de mudança de unidade de estudo (`initScopeControls`).

Na sequência:
- `indicator/static/indicator/css/custom.css` — estilos do spinner e do overlay;
- `indicator_journal/static/indicator_journal/js/journal_metrics_filters.js` — exibição do loading antes da navegação no botão Aplicar.

#### Como este poderia ser testado manualmente?
1. Abra a tela de indicadores (unidade de estudo *document* ou *source*).
2. Ajuste os filtros e clique em **FILTRAR** → o overlay com spinner deve aparecer sobre a área de resultados até os gráficos carregarem.
3. Clique em **LIMPAR** → o mesmo loading deve aparecer.
4. Altere a **variável de detalhamento** → o loading deve aparecer durante a atualização dos gráficos.
5. Altere a **unidade de estudo** (ex.: *document* → *source*) → a página recarrega e o loading deve aparecer **apenas uma vez** (no carregamento dos gráficos da nova página).
6. Acesse uma página de `journal_*_metrics` (global e por categoria), ajuste os filtros e clique em **Aplicar** → o loading deve aparecer antes da navegação.

#### Algum cenário de contexto que queira dar?
Buscou-se aproveitar a lógica já existente na em search. Buscou-se extrair as funções mais básicas para o search-gateway e ser aproveitado nas três apps (indicator, search e observation).

### Screenshots
**Loading: Funcionamento esperado a partir da incorporação do PR**
[Screencast_20260625_123736.webm](https://github.com/user-attachments/assets/394fcb9a-0876-463e-9136-cd9103e45ba8)

#### Quais são tickets relevantes?
#712 

### Referências
N/A