### PR TITLE
Remove uso de djanto.utils.timezone.utc que causava erro 500

### DIFF
--- a/core/utils/dates.py
+++ b/core/utils/dates.py
@@ -1,8 +1,8 @@
-from django.utils import timezone
+from datetime import datetime, timezone as dt_timezone
 
 
 def epoch_ms_to_datetime(raw):
     if not raw:
         return None
 
-    return timezone.datetime.fromtimestamp(float(raw) / 1000.0, tz=timezone.utc)
+    return datetime.fromtimestamp(float(raw) / 1000.0, tz=dt_timezone.utc)

--- a/django_celery_beat/utils.py
+++ b/django_celery_beat/utils.py
@@ -1,6 +1,8 @@
 """Utilities."""
 # -- XXX This module must not use translation as that causes
 # -- a recursive loader import!
+from datetime import timezone as dt_timezone
+
 from django.conf import settings
 from django.utils import timezone
 
@@ -17,7 +19,7 @@ def make_aware(value):
     if getattr(settings, "USE_TZ", False):
         # naive datetimes are assumed to be in UTC.
         if timezone.is_naive(value):
-            value = timezone.make_aware(value, timezone.utc)
+            value = timezone.make_aware(value, dt_timezone.utc)
         # then convert to the Django configured timezone.
         default_tz = timezone.get_default_timezone()
         value = timezone.localtime(value, default_tz)


### PR DESCRIPTION
#### O que esse PR faz?
Remove o uso do campo .utc do módulo django.utils.timezone. Em lugar disso, passa a usar o timezone originário do datetime.

#### Onde a revisão poderia começar?
Analise os dois arquivos alterados.

#### Como este poderia ser testado manualmente?
1. Rodar a versão antiga por meio de:
```python
from django.utils import timezone
timezone.make_aware(datetime.now(), timezone.utc)
```

2. Observar que o timezone do django.utils não tem o campo utc. Logo, o erro seguinte ocorre:

```text
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[22], line 1
----> 1 timezone.make_aware(datetime.now(), timezone.utc)

AttributeError: module 'django.utils.timezone' has no attribute 'utc'
```

3. Rodar o código novo por meio de:
```python
from datetime import timezone as dt_timezone
timezone.make_aware(datetime.now(), dt_timezone.utc)
datetime.datetime(2026, 6, 26, 19, 52, 9, 988008, tzinfo=datetime.timezone.utc)
```

4. Observar que o erro deixa de existir

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#722 

### Referências
N/A

