### PR TITLE
Improve global metrics silver apply performance and reliability

### DIFF
--- a/harvest/global_metrics/apply.py
+++ b/harvest/global_metrics/apply.py
@@ -46,10 +46,7 @@ def apply_global_metrics_upload_to_silver(
     }
     unresolved_countries = set()
 
-    # Consome o scroll por completo antes de processar, para não manter o
-    # contexto de scroll aberto durante os lookups/updates (que podem exceder
-    # o keep-alive e expirar o scroll). O footprint em memória é equivalente ao
-    # set de deduplicação que iter_silver_issn_year_groups já mantém.
+
     silver_groups = list(
         iter_silver_issn_year_groups(
             client=client,

--- a/harvest/global_metrics/apply.py
+++ b/harvest/global_metrics/apply.py
@@ -46,10 +46,18 @@ def apply_global_metrics_upload_to_silver(
     }
     unresolved_countries = set()
 
-    for silver_group in iter_silver_issn_year_groups(
-        client=client,
-        silver_index=silver_index,
-    ):
+    # Consome o scroll por completo antes de processar, para não manter o
+    # contexto de scroll aberto durante os lookups/updates (que podem exceder
+    # o keep-alive e expirar o scroll). O footprint em memória é equivalente ao
+    # set de deduplicação que iter_silver_issn_year_groups já mantém.
+    silver_groups = list(
+        iter_silver_issn_year_groups(
+            client=client,
+            silver_index=silver_index,
+        )
+    )
+
+    for silver_group in silver_groups:
         stats["silver_groups_seen"] += 1
         stats["harvest_lookups"] += 1
         group = find_global_metric_group_for_silver_group(

--- a/harvest/global_metrics/opensearch.py
+++ b/harvest/global_metrics/opensearch.py
@@ -203,7 +203,7 @@ def update_silver_group_by_query(client, silver_index, group):
     )
 
 
-def scroll_hits(client, index, body, scroll="5m"):
+def scroll_hits(client, index, body, scroll="20m"):
     response = client.search(index=index, body=body, scroll=scroll)
     scroll_id = response.get("_scroll_id")
     try:

--- a/harvest/global_metrics/opensearch.py
+++ b/harvest/global_metrics/opensearch.py
@@ -199,7 +199,7 @@ def update_silver_group_by_query(client, silver_index, group):
         index=silver_index,
         body=build_global_metrics_update_by_query_body(group),
         conflicts="proceed",
-        refresh=True,
+        refresh=False,
     )
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Melhora a confiabilidade e a performance da aplicação de métricas globais no índice silver durante o processamento de uploads no Wagtail.

As mudanças resolvem dois pontos do fluxo `apply_global_metrics_upload_to_silver`:

- **Materialização prévia dos grupos silver**: os pares `(year, issn)` passam a ser coletados por completo antes dos lookups no índice de harvest e dos `update_by_query` no silver. Isso fecha o scroll do OpenSearch cedo e evita expiração do contexto (`scroll=5m`) enquanto operações demoradas de rede/banco acontecem.
- **Menos pressão no cluster durante updates em lote**: cada `update_by_query` deixa de forçar `refresh=True`, reduzindo o custo de refresh por grupo processado.

#### Onde a revisão poderia começar?
- `harvest/global_metrics/apply.py` — ponto de entrada do fluxo e materialização dos grupos silver.
- `harvest/global_metrics/opensearch.py` — função `update_silver_group_by_query` com `refresh=False`.

#### Como este poderia ser testado manualmente?
1. Subir o ambiente local com OpenSearch e Celery worker.
2. Fazer upload de um arquivo de métricas globais no Wagtail e aguardar a indexação do arquivo.
3. Acionar a aplicação das métricas no silver (ação disponível no admin/snippet de upload).
4. Verificar nos logs da task Celery que `groups_processed`, `matches_found` e `updated` são preenchidos corretamente.
5. Confirmar que o job conclui sem erro de scroll expirado em execuções com muitos grupos.
6. Consultar documentos afetados no índice silver e validar que os campos `oca_data.scielo.source.indexed_in` e `country_code` foram atualizados após o término da task.

#### Algum cenário de contexto que queira dar?
No fluxo anterior, o scroll do índice silver permanecia aberto enquanto cada grupo passava por lookup no harvest e por `update_by_query` no silver. Em jobs longos, isso podia ultrapassar o keep-alive de 5 minutos e interromper o processamento.

A materialização dos grupos antes do processamento elimina esse risco sem alterar a semântica do pipeline, pois o conjunto de deduplicação `(year, issn)` já era mantido em memória internamente.

A troca de `refresh=True` para `refresh=False` segue o padrão já adotado em outros fluxos batch do projeto (`harvest/indexing.py`, `normalize_bronze_language.py`), priorizando performance em operações em lote.

### Screenshots
N/A — alteração de backend/processamento assíncrono, sem impacto visual direto.

#### Quais são tickets relevantes?
N/A

### Referências
- Discussão sobre expiração de scroll context no OpenSearch/Elasticsearch (`scroll=5m`).
- Padrão de batch indexing do projeto com `refresh=False` durante loops e refresh controlado ao final, quando necessário.


## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): Preciso de instruções de como proceder com esta etapa.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)