### PR TITLE
Adiciona regiões do mundo aos documentos científicos

### DIFF
--- a/etl/management/commands/apply_world_regions_to_silver.py
+++ b/etl/management/commands/apply_world_regions_to_silver.py
@@ -1,0 +1,113 @@
+import json
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from etl.world_regions import apply_world_regions
+from search_gateway.client import get_opensearch_client
+
+
+class Command(BaseCommand):
+    help = "Aplica as sub-regiões geográficas UN M49 aos documentos silver."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--index",
+            default=settings.ETL_PUBLIC_ALIAS,
+            help="Índice ou alias silver de destino.",
+        )
+        parser.add_argument(
+            "--slices",
+            default="auto",
+            help="Quantidade de slices paralelos ou 'auto'.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=1000,
+            help="Documentos processados por lote.",
+        )
+        parser.add_argument(
+            "--requests-per-second",
+            type=float,
+            default=500,
+            help="Limite global de documentos processados por segundo.",
+        )
+        parser.add_argument(
+            "--repair",
+            action="store_true",
+            help="Recalcula também documentos que já possuem região.",
+        )
+        parser.add_argument(
+            "--task-id",
+            help="Consulta uma execução existente.",
+        )
+        parser.add_argument(
+            "--cancel",
+            action="store_true",
+            help="Cancela a execução indicada por --task-id.",
+        )
+
+    def handle(self, *args, **options):
+        client = get_opensearch_client()
+
+        if client is None:
+            raise CommandError("Cliente OpenSearch não configurado.")
+
+        task_id = options["task_id"]
+
+        if options["cancel"]:
+            if not task_id:
+                raise CommandError("--cancel exige --task-id.")
+
+            result = client.tasks.cancel(task_id=task_id)
+            self.stdout.write(json.dumps(result, indent=2))
+            return
+
+        if task_id:
+            result = client.tasks.get(task_id=task_id)
+            self.stdout.write(json.dumps(result, indent=2))
+            return
+
+        slices = options["slices"]
+
+        if slices != "auto":
+            try:
+                slices = int(slices)
+            except ValueError as error:
+                raise CommandError("--slices deve ser 'auto' ou um inteiro.") from error
+
+            if slices <= 0:
+                raise CommandError("--slices deve ser maior que zero.")
+
+        if options["batch_size"] <= 0:
+            raise CommandError("--batch-size deve ser maior que zero.")
+
+        if options["requests_per_second"] <= 0:
+            raise CommandError("--requests-per-second deve ser maior que zero.")
+
+        try:
+            result = apply_world_regions(
+                client,
+                options["index"],
+                slices,
+                options["batch_size"],
+                options["requests_per_second"],
+                options["repair"],
+            )
+        except Exception as error:
+            raise CommandError(str(error)) from error
+
+        task_id = result.get("task")
+
+        if not task_id:
+            raise CommandError("O OpenSearch não retornou o identificador da task.")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Backfill iniciado. Task: {task_id}\n"
+                "Consulte com: "
+                "python manage.py apply_world_regions_to_silver "
+                f"--task-id {task_id}"
+            )
+        )

--- a/etl/management/commands/backfill_openalex_silver.py
+++ b/etl/management/commands/backfill_openalex_silver.py
@@ -9,6 +9,7 @@ from etl.documents import RawOpenAlexInputDocument
 from etl.mapping_silver import SILVER_MAPPING
 from etl.transform.normalizers import normalize_openalex_id
 from etl.transform.standardizer import OpenAlexStandardizer
+from etl.world_regions import add_world_regions
 from harvest.utils import clean_source_payload
 
 logger = logging.getLogger(__name__)
@@ -239,13 +240,20 @@ class Command(BaseCommand):
                         continue
 
                     if not dry_run:
-                        actions.append({
-                            "index": {
-                                "_index": write_alias,
-                                "_id": oa_id,
-                            }
-                        })
-                        actions.append(silver_doc.to_index_dict())
+                        source = silver_doc.to_index_dict()
+                        add_world_regions(source)
+
+                        actions.extend(
+                            [
+                                {
+                                    "index": {
+                                        "_index": write_alias,
+                                        "_id": oa_id,
+                                    }
+                                },
+                                source,
+                            ]
+                        )
 
                 if actions and not dry_run:
                     try:

--- a/etl/management/commands/backfill_openalex_silver.py
+++ b/etl/management/commands/backfill_openalex_silver.py
@@ -9,7 +9,7 @@ from etl.documents import RawOpenAlexInputDocument
 from etl.mapping_silver import SILVER_MAPPING
 from etl.transform.normalizers import normalize_openalex_id
 from etl.transform.standardizer import OpenAlexStandardizer
-from etl.world_regions import add_world_regions
+from etl.world_regions import add_affiliation_world_regions, add_source_world_region
 from harvest.utils import clean_source_payload
 
 logger = logging.getLogger(__name__)
@@ -241,7 +241,8 @@ class Command(BaseCommand):
 
                     if not dry_run:
                         source = silver_doc.to_index_dict()
-                        add_world_regions(source)
+                        add_source_world_region(source)
+                        add_affiliation_world_regions(source)
 
                         actions.extend(
                             [

--- a/etl/mapping_silver.py
+++ b/etl/mapping_silver.py
@@ -89,6 +89,7 @@ SILVER_PROPERTIES = {
                         "type": "object",
                         "properties": {
                             "country_code": {"type": "keyword"},
+                            "world_region": {"type": "keyword"},
                             "indexed_in": {"type": "keyword"},
                         },
                     },
@@ -98,6 +99,12 @@ SILVER_PROPERTIES = {
                 "type": "object",
                 "properties": {
                     "ids": {"type": "keyword"},
+                    "affiliations": {
+                        "type": "object",
+                        "properties": {
+                            "world_regions": {"type": "keyword"},
+                        },
+                    },
                     "versions": {
                         "type": "nested",
                         "properties": {

--- a/etl/pipeline.py
+++ b/etl/pipeline.py
@@ -19,7 +19,7 @@ from etl.transform.normalizers import (
     normalize_text,
 )
 from etl.transform.standardizer import standardizer_for
-from etl.world_regions import add_world_regions
+from etl.world_regions import add_affiliation_world_regions, add_source_world_region
 from harvest.utils import clean_source_payload
 
 logger = logging.getLogger(__name__)
@@ -604,7 +604,8 @@ class OpenSearchETLPipeline:
                 }
             }
             source = doc.to_index_dict()
-            add_world_regions(source)
+            add_source_world_region(source)
+            add_affiliation_world_regions(source)
             action_bytes = self._bulk_action_size_bytes(action, source)
 
             if actions and (chunk_docs >= max_docs or chunk_bytes + action_bytes > max_bytes):

--- a/etl/pipeline.py
+++ b/etl/pipeline.py
@@ -7,10 +7,10 @@ from typing import Any, Dict, List, Optional
 from django.conf import settings
 
 from etl.client import OpenSearchClient
-from etl.documents import SilverDocument
-from etl.mapping_silver import SILVER_MAPPING
 from etl.deduplicator.openalex import OpenAlexMatcher
 from etl.deduplicator.scielo import SciELODeduplicator
+from etl.documents import SilverDocument
+from etl.mapping_silver import SILVER_MAPPING
 from etl.models import EtlPipelineConfig
 from etl.transform.merger import SilverMerger
 from etl.transform.normalizers import (
@@ -19,6 +19,7 @@ from etl.transform.normalizers import (
     normalize_text,
 )
 from etl.transform.standardizer import standardizer_for
+from etl.world_regions import add_world_regions
 from harvest.utils import clean_source_payload
 
 logger = logging.getLogger(__name__)
@@ -603,6 +604,7 @@ class OpenSearchETLPipeline:
                 }
             }
             source = doc.to_index_dict()
+            add_world_regions(source)
             action_bytes = self._bulk_action_size_bytes(action, source)
 
             if actions and (chunk_docs >= max_docs or chunk_bytes + action_bytes > max_bytes):

--- a/etl/tests/domain/test_world_regions.py
+++ b/etl/tests/domain/test_world_regions.py
@@ -42,6 +42,14 @@ class WorldRegionsTests(SimpleTestCase):
         for country_code in ("", "BRA", "INVALID", None):
             with self.subTest(country_code=country_code):
                 self.assertIsNone(world_region_for_country(country_code))
+
+    def test_ignores_document_without_source(self):
+        document = {"oca_data": {}}
+
+        add_source_world_region(document)
+
+        self.assertEqual(document, {"oca_data": {}})
+
     def test_adds_and_removes_unique_affiliation_world_regions(self):
         document = {
             "author_country_codes": ["BR", "JP", "BR"],

--- a/etl/tests/domain/test_world_regions.py
+++ b/etl/tests/domain/test_world_regions.py
@@ -10,7 +10,7 @@ from etl.world_regions import (
 )
 
 
-class WorldRegionsBackfillTests(SimpleTestCase):
+class WorldRegionsTests(SimpleTestCase):
     def setUp(self):
         self.client = Mock()
         self.client.indices.get_field_mapping.return_value = {
@@ -38,6 +38,10 @@ class WorldRegionsBackfillTests(SimpleTestCase):
         self.assertEqual(world_region_for_country("GB"), "Northern Europe")
         self.assertEqual(world_region_for_country("GR"), "Southern Europe")
 
+    def test_returns_none_for_invalid_country_codes(self):
+        for country_code in ("", "BRA", "INVALID", None):
+            with self.subTest(country_code=country_code):
+                self.assertIsNone(world_region_for_country(country_code))
     def test_starts_incremental_async_backfill(self):
         self.client.update_by_query.return_value = {"task": "node:1"}
 

--- a/etl/tests/domain/test_world_regions.py
+++ b/etl/tests/domain/test_world_regions.py
@@ -42,6 +42,26 @@ class WorldRegionsTests(SimpleTestCase):
         for country_code in ("", "BRA", "INVALID", None):
             with self.subTest(country_code=country_code):
                 self.assertIsNone(world_region_for_country(country_code))
+    def test_adds_and_removes_unique_affiliation_world_regions(self):
+        document = {
+            "author_country_codes": ["BR", "JP", "BR"],
+            "oca_data": {},
+        }
+
+        add_affiliation_world_regions(document)
+
+        affiliations = document["oca_data"]["openalex"]["affiliations"]
+        self.assertEqual(
+            affiliations["world_regions"],
+            ["Eastern Asia", "South America"],
+        )
+
+        document.pop("author_country_codes")
+
+        add_affiliation_world_regions(document)
+
+        self.assertNotIn("world_regions", affiliations)
+
     def test_starts_incremental_async_backfill(self):
         self.client.update_by_query.return_value = {"task": "node:1"}
 

--- a/etl/tests/domain/test_world_regions.py
+++ b/etl/tests/domain/test_world_regions.py
@@ -43,6 +43,28 @@ class WorldRegionsTests(SimpleTestCase):
             with self.subTest(country_code=country_code):
                 self.assertIsNone(world_region_for_country(country_code))
 
+    def test_adds_and_removes_source_world_region_for_unknown_country(self):
+        document = {
+            "oca_data": {
+                "scielo": {
+                    "source": {
+                        "country_code": "BR",
+                    },
+                },
+            },
+        }
+        source = document["oca_data"]["scielo"]["source"]
+
+        add_source_world_region(document)
+
+        self.assertEqual(source["world_region"], "South America")
+
+        source["country_code"] = "INVALID"
+
+        add_source_world_region(document)
+
+        self.assertNotIn("world_region", source)
+
     def test_ignores_document_without_source(self):
         document = {"oca_data": {}}
 

--- a/etl/tests/domain/test_world_regions.py
+++ b/etl/tests/domain/test_world_regions.py
@@ -2,7 +2,12 @@ from unittest.mock import Mock
 
 from django.test import SimpleTestCase
 
-from etl.world_regions import apply_world_regions, world_region_for_country
+from etl.world_regions import (
+    add_affiliation_world_regions,
+    add_source_world_region,
+    apply_world_regions,
+    world_region_for_country,
+)
 
 
 class WorldRegionsBackfillTests(SimpleTestCase):

--- a/etl/tests/domain/test_world_regions.py
+++ b/etl/tests/domain/test_world_regions.py
@@ -1,0 +1,93 @@
+from unittest.mock import Mock
+
+from django.test import SimpleTestCase
+
+from etl.world_regions import apply_world_regions, world_region_for_country
+
+
+class WorldRegionsBackfillTests(SimpleTestCase):
+    def setUp(self):
+        self.client = Mock()
+        self.client.indices.get_field_mapping.return_value = {
+            "silver": {
+                "mappings": {
+                    "oca_data.scielo.source.world_region": {
+                        "mapping": {
+                            "world_region": {
+                                "type": "keyword",
+                            },
+                        },
+                    },
+                    "oca_data.openalex.affiliations.world_regions": {
+                        "mapping": {
+                            "world_regions": {
+                                "type": "keyword",
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+    def test_maps_canonical_iso_country_codes(self):
+        self.assertEqual(world_region_for_country("GB"), "Northern Europe")
+        self.assertEqual(world_region_for_country("GR"), "Southern Europe")
+
+    def test_starts_incremental_async_backfill(self):
+        self.client.update_by_query.return_value = {"task": "node:1"}
+
+        result = apply_world_regions(
+            self.client,
+            "silver",
+            "auto",
+            1000,
+            500,
+            False,
+        )
+
+        self.assertEqual(result, {"task": "node:1"})
+        self.client.indices.get_field_mapping.assert_called_once_with(
+            index="silver",
+            fields=(
+                "oca_data.scielo.source.world_region,"
+                "oca_data.openalex.affiliations.world_regions"
+            ),
+        )
+        request = self.client.update_by_query.call_args.kwargs
+        self.assertEqual(
+            request["params"],
+            {
+                "conflicts": "proceed",
+                "refresh": "false",
+                "wait_for_completion": "false",
+                "slices": "auto",
+                "scroll_size": 1000,
+                "requests_per_second": 500,
+            },
+        )
+        self.assertIn(
+            "must_not",
+            request["body"]["query"]["bool"]["should"][0]["bool"],
+        )
+
+    def test_rejects_index_without_world_region_mapping(self):
+        self.client.indices.get_field_mapping.return_value = {
+            "silver": {
+                "mappings": {},
+            },
+        }
+
+        with self.assertRaisesMessage(
+            RuntimeError,
+            "Aplique docs/Regioes-do-mundo.md antes do backfill.",
+        ):
+            apply_world_regions(
+                self.client,
+                "silver",
+                "auto",
+                1000,
+                500,
+                False,
+            )
+
+        self.client.update_by_query.assert_not_called()

--- a/etl/tests/pipeline/test_pipeline_indexing.py
+++ b/etl/tests/pipeline/test_pipeline_indexing.py
@@ -39,7 +39,7 @@ class WorldRegionIndexingTests(SimpleTestCase):
             doc_id="S001",
             type="article",
             publication_year=2024,
-            author_country_codes=["BR", "JP"],
+            author_country_codes=["BR", "JP", "BR"],
             oca_data={
                 "scielo": {"source": {"country_code": "BR"}},
                 "openalex": {},

--- a/etl/tests/pipeline/test_pipeline_indexing.py
+++ b/etl/tests/pipeline/test_pipeline_indexing.py
@@ -1,10 +1,62 @@
 from unittest.mock import Mock, patch
 
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from etl.documents import SilverDocument
 from etl.mapping_silver import SILVER_MAPPING
 from etl.pipeline import OpenSearchETLPipeline
+
+
+class WorldRegionIndexingTests(SimpleTestCase):
+    @patch("etl.pipeline.standardizer_for")
+    @patch("etl.pipeline.OpenAlexMatcher")
+    @patch("etl.pipeline.SciELODeduplicator")
+    @patch("etl.pipeline.OpenSearchClient")
+    def test_indexing_adds_un_m49_world_regions(
+        self,
+        client_cls,
+        _scielo_deduplicator_cls,
+        _openalex_matcher_cls,
+        _standardizer_for,
+    ):
+        client = Mock()
+        client.client.bulk.return_value = {"errors": False}
+        client.ensure_rollover_index.return_value = (
+            "silver_scientific_production-000001"
+        )
+        client.rollover.return_value = None
+        client_cls.return_value = client
+        pipeline_config = Mock(
+            default_document_type="article",
+            deduplicate_scielo=False,
+        )
+        pipeline_config.openalex_index_for.return_value = "bronze_openalex_works"
+        pipeline = OpenSearchETLPipeline(
+            opensearch_url="http://opensearch:9200",
+            pipeline_config=pipeline_config,
+        )
+        doc = SilverDocument(
+            doc_id="S001",
+            type="article",
+            publication_year=2024,
+            author_country_codes=["BR", "JP"],
+            oca_data={
+                "scielo": {"source": {"country_code": "BR"}},
+                "openalex": {},
+            },
+        )
+
+        pipeline._index_silver_documents([doc])
+
+        indexed = client.client.bulk.call_args.kwargs["body"][1]
+        self.assertEqual(
+            indexed["oca_data"]["scielo"]["source"]["world_region"],
+            "South America",
+        )
+        self.assertEqual(
+            indexed["oca_data"]["openalex"]["affiliations"]["world_regions"],
+            ["Eastern Asia", "South America"],
+        )
 
 
 class OrchestratorAliasTests(TestCase):

--- a/etl/world_regions.py
+++ b/etl/world_regions.py
@@ -95,23 +95,21 @@ def world_region_for_country(country_code):
     return country_world_regions().get(country_code.strip().upper())
 
 
-def add_world_regions(document):
-    oca_data = document.get("oca_data")
+def add_source_world_region(document):
+    source = document["oca_data"].get("scielo", {}).get("source")
 
-    if not isinstance(oca_data, dict):
+    if source is None:
         return
 
-    scielo = oca_data.get("scielo")
-    source = scielo.get("source") if isinstance(scielo, dict) else None
+    region = world_region_for_country(source.get("country_code"))
 
-    if isinstance(source, dict):
-        region = world_region_for_country(source.get("country_code"))
+    if region:
+        source["world_region"] = region
+    else:
+        source.pop("world_region", None)
 
-        if region:
-            source["world_region"] = region
-        else:
-            source.pop("world_region", None)
 
+def add_affiliation_world_regions(document):
     regions = sorted(
         {
             region
@@ -119,25 +117,17 @@ def add_world_regions(document):
             if (region := world_region_for_country(country_code))
         }
     )
-    openalex = oca_data.get("openalex")
+    oca_data = document["oca_data"]
+    affiliations = oca_data.get("openalex", {}).get("affiliations")
 
     if regions:
-        if not isinstance(openalex, dict):
-            openalex = {}
-            oca_data["openalex"] = openalex
-
-        affiliations = openalex.get("affiliations")
-
-        if not isinstance(affiliations, dict):
-            affiliations = {}
-            openalex["affiliations"] = affiliations
-
+        affiliations = oca_data.setdefault("openalex", {}).setdefault(
+            "affiliations",
+            {},
+        )
         affiliations["world_regions"] = regions
-    elif isinstance(openalex, dict):
-        affiliations = openalex.get("affiliations")
-
-        if isinstance(affiliations, dict):
-            affiliations.pop("world_regions", None)
+    elif affiliations is not None:
+        affiliations.pop("world_regions", None)
 
 
 def apply_world_regions(

--- a/etl/world_regions.py
+++ b/etl/world_regions.py
@@ -1,0 +1,261 @@
+from functools import lru_cache
+
+import country_converter
+import pycountry
+
+WORLD_REGIONS_UPDATE_SCRIPT = """
+    boolean changed = false;
+    def ocaData = ctx._source.oca_data;
+    def scielo = ocaData != null ? ocaData.scielo : null;
+    def source = scielo != null ? scielo.source : null;
+
+    if (source != null) {
+        def countryCode = source.country_code;
+        def expectedRegion =
+            countryCode != null ? params.mapping[countryCode] : null;
+        def currentRegion = source.world_region;
+
+        if (expectedRegion == null && currentRegion != null) {
+            source.remove('world_region');
+            changed = true;
+        } else if (
+            expectedRegion != null && !expectedRegion.equals(currentRegion)
+        ) {
+            source.world_region = expectedRegion;
+            changed = true;
+        }
+    }
+
+    def expectedRegions = new ArrayList();
+    def uniqueRegions = new HashSet();
+
+    for (def countryCode : ctx._source.author_country_codes ?: []) {
+        def region = params.mapping[countryCode];
+
+        if (region != null) {
+            uniqueRegions.add(region);
+        }
+    }
+
+    expectedRegions.addAll(uniqueRegions);
+    Collections.sort(expectedRegions);
+
+    def openalex = ocaData != null ? ocaData.openalex : null;
+    def affiliations = openalex != null ? openalex.affiliations : null;
+    def currentRegions =
+        affiliations != null ? affiliations.world_regions : null;
+
+    if (expectedRegions.isEmpty()) {
+        if (currentRegions != null) {
+            affiliations.remove('world_regions');
+            changed = true;
+        }
+    } else if (!expectedRegions.equals(currentRegions)) {
+        if (ocaData == null) {
+            ocaData = new HashMap();
+            ctx._source.oca_data = ocaData;
+        }
+        if (ocaData.openalex == null) {
+            ocaData.openalex = new HashMap();
+        }
+        if (ocaData.openalex.affiliations == null) {
+            ocaData.openalex.affiliations = new HashMap();
+        }
+
+        ocaData.openalex.affiliations.world_regions = expectedRegions;
+        changed = true;
+    }
+
+    if (!changed) {
+        ctx.op = 'noop';
+    }
+"""
+
+
+@lru_cache(maxsize=1)
+def country_world_regions():
+    country_codes = sorted(country.alpha_2 for country in pycountry.countries)
+    regions = country_converter.CountryConverter().convert(
+        names=country_codes,
+        src="ISO2",
+        to="UNregion",
+    )
+
+    return {
+        country_code: region
+        for country_code, region in zip(country_codes, regions)
+        if isinstance(region, str) and region != "not found"
+    }
+
+
+def world_region_for_country(country_code):
+    if not isinstance(country_code, str):
+        return None
+
+    return country_world_regions().get(country_code.strip().upper())
+
+
+def add_world_regions(document):
+    oca_data = document.get("oca_data")
+
+    if not isinstance(oca_data, dict):
+        return
+
+    scielo = oca_data.get("scielo")
+    source = scielo.get("source") if isinstance(scielo, dict) else None
+
+    if isinstance(source, dict):
+        region = world_region_for_country(source.get("country_code"))
+
+        if region:
+            source["world_region"] = region
+        else:
+            source.pop("world_region", None)
+
+    regions = sorted(
+        {
+            region
+            for country_code in document.get("author_country_codes") or []
+            if (region := world_region_for_country(country_code))
+        }
+    )
+    openalex = oca_data.get("openalex")
+
+    if regions:
+        if not isinstance(openalex, dict):
+            openalex = {}
+            oca_data["openalex"] = openalex
+
+        affiliations = openalex.get("affiliations")
+
+        if not isinstance(affiliations, dict):
+            affiliations = {}
+            openalex["affiliations"] = affiliations
+
+        affiliations["world_regions"] = regions
+    elif isinstance(openalex, dict):
+        affiliations = openalex.get("affiliations")
+
+        if isinstance(affiliations, dict):
+            affiliations.pop("world_regions", None)
+
+
+def apply_world_regions(
+    client,
+    index_name,
+    slices,
+    batch_size,
+    requests_per_second,
+    repair,
+):
+    required_fields = {
+        "oca_data.scielo.source.world_region": "world_region",
+        "oca_data.openalex.affiliations.world_regions": "world_regions",
+    }
+    mappings = client.indices.get_field_mapping(
+        index=index_name,
+        fields=",".join(required_fields),
+    )
+    invalid_fields = []
+
+    for concrete_index, index_mapping in mappings.items():
+        fields = index_mapping.get("mappings") or {}
+
+        for field_name, leaf_name in required_fields.items():
+            field_type = (
+                fields.get(field_name, {})
+                .get("mapping", {})
+                .get(leaf_name, {})
+                .get("type")
+            )
+
+            if field_type != "keyword":
+                invalid_fields.append(f"{concrete_index}:{field_name}")
+
+    if not mappings:
+        invalid_fields.append(index_name)
+
+    if invalid_fields:
+        fields = ", ".join(invalid_fields)
+
+        raise RuntimeError(
+            f"Mapping de regiões ausente ou incompatível em {fields}. "
+            "Aplique docs/Regioes-do-mundo.md antes do backfill."
+        )
+
+    if repair:
+        query = {
+            "bool": {
+                "should": [
+                    {"exists": {"field": "oca_data.scielo.source.country_code"}},
+                    {"exists": {"field": "author_country_codes"}},
+                    {"exists": {"field": "oca_data.scielo.source.world_region"}},
+                    {
+                        "exists": {
+                            "field": "oca_data.openalex.affiliations.world_regions"
+                        }
+                    },
+                ],
+                "minimum_should_match": 1,
+            }
+        }
+    else:
+        query = {
+            "bool": {
+                "should": [
+                    {
+                        "bool": {
+                            "filter": {
+                                "exists": {
+                                    "field": "oca_data.scielo.source.country_code"
+                                }
+                            },
+                            "must_not": {
+                                "exists": {
+                                    "field": "oca_data.scielo.source.world_region"
+                                }
+                            },
+                        }
+                    },
+                    {
+                        "bool": {
+                            "filter": {
+                                "exists": {
+                                    "field": "author_country_codes"
+                                }
+                            },
+                            "must_not": {
+                                "exists": {
+                                    "field": (
+                                        "oca_data.openalex.affiliations.world_regions"
+                                    )
+                                }
+                            },
+                        }
+                    },
+                ],
+                "minimum_should_match": 1,
+            }
+        }
+
+    body = {
+        "query": query,
+        "script": {
+            "lang": "painless",
+            "source": WORLD_REGIONS_UPDATE_SCRIPT,
+            "params": {"mapping": country_world_regions()},
+        },
+    }
+
+    return client.update_by_query(
+        index=index_name,
+        body=body,
+        params={
+            "conflicts": "proceed",
+            "refresh": "false",
+            "wait_for_completion": "false",
+            "slices": slices,
+            "scroll_size": batch_size,
+            "requests_per_second": requests_per_second,
+        },
+    )

--- a/harvest/global_metrics/opensearch.py
+++ b/harvest/global_metrics/opensearch.py
@@ -1,4 +1,5 @@
 from etl.transform.normalizers import normalize_issn
+from etl.world_regions import world_region_for_country
 from harvest.global_metrics.parsing import (
     append_unique,
     coerce_int,
@@ -169,11 +170,18 @@ def global_metrics_update_script():
         }
         if (params.country_codes != null && params.country_codes.size() > 0) {
             ctx._source.oca_data.scielo.source.country_code = params.country_codes.get(0);
+            if (params.world_region != null) {
+                ctx._source.oca_data.scielo.source.world_region = params.world_region;
+            } else {
+                ctx._source.oca_data.scielo.source.remove('world_region');
+            }
         }
     """
 
 
 def build_global_metrics_update_by_query_body(group):
+    country_code = group["country_codes"][0] if group["country_codes"] else None
+
     return {
         "query": {
             "bool": {
@@ -189,6 +197,7 @@ def build_global_metrics_update_by_query_body(group):
             "params": {
                 "indexed_in": sorted(group["indexed_in"]),
                 "country_codes": group["country_codes"],
+                "world_region": world_region_for_country(country_code),
             },
         },
     }

--- a/harvest/tests.py
+++ b/harvest/tests.py
@@ -204,6 +204,7 @@ class GlobalMetricsUploadTaskTests(SimpleTestCase):
         params = body["script"]["params"]
         self.assertEqual(params["indexed_in"], ["Scopus", "WoS"])
         self.assertEqual(params["country_codes"], ["BR"])
+        self.assertEqual(params["world_region"], "South America")
         self.assertIn("oca_data.scielo.source", body["script"]["source"])
 
     @override_settings(GLOBAL_METRICS_UPLOAD_ERROR_INDEX="global_metrics_upload_errors")

--- a/observation/seed_dimensions.py
+++ b/observation/seed_dimensions.py
@@ -18,6 +18,7 @@ DIMENSION_SPECS_BY_INDEX = {
             "table_title": f"{SCIENTIFIC_TABLE_TITLE_PREFIX}Affiliation - Region of the World",
             "row_label": "Region of the World",
             "row_field_candidates": [
+                "affiliation_world_region",
                 "world_region",
                 "author_world_region",
                 "region",
@@ -135,6 +136,14 @@ DIMENSION_SPECS_BY_INDEX = {
             "table_title": f"{SCIENTIFIC_TABLE_TITLE_PREFIX}Source Country",
             "row_label": "Source Country",
             "row_field_candidates": ["source_country"],
+            "is_default": False,
+        },
+        {
+            "slug": "documents-by-source-region-world",
+            "menu_label": "Source - Region of the World",
+            "table_title": f"{SCIENTIFIC_TABLE_TITLE_PREFIX}Source - Region of the World",
+            "row_label": "Region of the World",
+            "row_field_candidates": ["source_world_region"],
             "is_default": False,
         },
         {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -67,6 +67,7 @@ drf-yasg==1.21.14  # https://pypi.org/project/drf-yasg2/
 
 # Pandas
 # ------------------------------------------------------------------------------
+country_converter==1.3.2
 numpy==2.4.1  # https://numpy.org/
 pandas==3.0.0 # https://pandas.pydata.org/
 python-calamine==0.6.2  # https://github.com/dimastbk/python-calamine

--- a/search_gateway/fixtures/datasources.json
+++ b/search_gateway/fixtures/datasources.json
@@ -41,6 +41,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -49,6 +50,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -86,6 +88,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -94,6 +97,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -130,6 +134,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -138,6 +143,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -174,6 +180,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -182,6 +189,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -215,6 +223,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -223,6 +232,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -326,6 +336,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -334,6 +345,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -371,6 +383,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -379,6 +392,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -416,6 +430,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -424,6 +439,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -461,6 +477,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -469,6 +486,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -505,6 +523,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -513,6 +532,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             },
@@ -572,6 +592,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -580,6 +601,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -616,6 +638,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -624,6 +647,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             },
@@ -680,6 +704,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -688,6 +713,53 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
+                "funder"
+              ]
+            }
+          },
+          "source_world_region": {
+            "kind": "index",
+            "index_field_name": "oca_data.scielo.source.world_region",
+            "filter": {
+              "size": 30,
+              "order": {
+                "_key": "asc"
+              }
+            },
+            "settings": {
+              "label": "Source World Region",
+              "support_query_operator": false,
+              "widget": "select",
+              "multiple_selection": true,
+              "group": "source",
+              "group_order": 20,
+              "include_all_option": true,
+              "all_option_label": "All",
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "source_world_region",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -724,6 +796,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_field",
                 "primary_topic_subfield",
@@ -732,6 +805,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ],
               "lookup_use_data_source_values": true
@@ -784,6 +858,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_subfield",
@@ -792,6 +867,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ],
               "lookup_use_data_source_values": true
@@ -844,6 +920,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -852,6 +929,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ],
               "lookup_use_data_source_values": true
@@ -904,6 +982,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -912,6 +991,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ],
               "lookup_use_data_source_values": true
@@ -964,6 +1044,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -972,6 +1053,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -1008,6 +1090,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -1016,6 +1099,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             },
@@ -1072,6 +1156,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -1080,6 +1165,53 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
+                "funder"
+              ]
+            }
+          },
+          "affiliation_world_region": {
+            "kind": "index",
+            "index_field_name": "oca_data.openalex.affiliations.world_regions",
+            "filter": {
+              "size": 30,
+              "order": {
+                "_key": "asc"
+              }
+            },
+            "settings": {
+              "label": "Affiliation World Region",
+              "support_query_operator": false,
+              "widget": "select",
+              "multiple_selection": true,
+              "group": "affiliation_funding",
+              "group_order": 40,
+              "include_all_option": true,
+              "all_option_label": "All",
+              "search_threshold": 10,
+              "dependencies": [
+                "scope",
+                "source_indexed_in",
+                "source_scielo_indexed_in",
+                "collection",
+                "document_type",
+                "document_language",
+                "open_access",
+                "open_access_status",
+                "source_name",
+                "source_type",
+                "publisher",
+                "source_country",
+                "source_world_region",
+                "publication_year",
+                "primary_topic_domain",
+                "primary_topic_field",
+                "primary_topic_subfield",
+                "primary_topic_name",
+                "sdg",
+                "institution",
+                "country",
+                "affiliation_world_region",
                 "funder"
               ]
             }
@@ -1116,6 +1248,7 @@
                 "source_type",
                 "publisher",
                 "source_country",
+                "source_world_region",
                 "publication_year",
                 "primary_topic_domain",
                 "primary_topic_field",
@@ -1124,6 +1257,7 @@
                 "sdg",
                 "institution",
                 "country",
+                "affiliation_world_region",
                 "funder"
               ]
             },
@@ -1393,6 +1527,7 @@
               "source_type",
               "publisher",
               "source_country",
+              "source_world_region",
               "primary_topic_domain",
               "primary_topic_field",
               "primary_topic_subfield",
@@ -1400,6 +1535,7 @@
               "sdg",
               "institution",
               "country",
+              "affiliation_world_region",
               "funder",
               "cited_by_count_range",
               "authors_count_range",
@@ -1431,6 +1567,7 @@
               "source_type",
               "publisher",
               "source_country",
+              "source_world_region",
               "primary_topic_domain",
               "primary_topic_field",
               "primary_topic_subfield",
@@ -1438,6 +1575,7 @@
               "sdg",
               "institution",
               "country",
+              "affiliation_world_region",
               "funder",
               "cited_by_count_range",
               "authors_count_range",


### PR DESCRIPTION
## O que esse PR faz?

Adiciona a classificação geográfica dos documentos científicos segundo as sub-regiões UN M49.

A implementação inclui:

- `oca_data.scielo.source.world_region`, calculado a partir do país da fonte;
- `oca_data.openalex.affiliations.world_regions`, calculado a partir dos países de afiliação dos autores;
- preenchimento automático das regiões em novos documentos silver;
- preenchimento da região quando o país da fonte é atualizado pelas métricas globais;
- suporte ao fluxo alternativo de documentos exclusivos do OpenAlex;
- comando assíncrono para preencher documentos existentes;
- execução incremental, modo de reparo, slicing, throttling, acompanhamento e cancelamento;
- filtros por região da fonte e das afiliações no datasource `silver_scientific_production`;
- dimensões de observação para as novas regiões;
- mapping `keyword` para novos índices e rollovers.

O backfill não altera o mapping. Ele apenas valida se os campos obrigatórios existem como `keyword` antes de iniciar.

## Onde a revisão poderia começar?

A revisão pode começar por:

1. `etl/world_regions.py`  
   Contém a conversão país → região, o enriquecimento de documentos, o script Painless e a execução do backfill.

2. `etl/management/commands/apply_world_regions_to_silver.py`  
   Contém a interface operacional para iniciar, acompanhar e cancelar o preenchimento.

3. `etl/pipeline.py`  
   Mostra a integração com a indexação de novos documentos silver.

Outros pontos relevantes:

- `etl/mapping_silver.py`
- `etl/management/commands/backfill_openalex_silver.py`
- `harvest/global_metrics/opensearch.py`
- `search_gateway/fixtures/datasources.json`
- `observation/seed_dimensions.py`
- `etl/tests/domain/test_world_regions.py`
- `etl/tests/pipeline/test_pipeline_indexing.py`

## Como este poderia ser testado manualmente?

### 1. Reconstruir a imagem

O PR adiciona a dependência `country_converter`:

```bash
docker compose -f local.yml build django
```

### 2. Executar os testes relacionados

```bash
docker compose -f local.yml run --rm django \
  pytest -q \
  etl/tests/domain/test_world_regions.py \
  etl/tests/pipeline/test_pipeline_indexing.py::WorldRegionIndexingTests \
  harvest/tests.py::GlobalMetricsUploadTaskTests::test_build_global_metrics_update_by_query_body_preserves_params
```

Resultado esperado:

```text
5 passed
```

### 3. Testar o enriquecimento em Python

```bash
docker compose -f local.yml run --rm django python manage.py shell -c '
from pprint import pprint

from etl.world_regions import (
    add_affiliation_world_regions,
    add_source_world_region,
)

document = {
    "author_country_codes": ["BR", "JP", "BR"],
    "oca_data": {
        "scielo": {
            "source": {
                "country_code": "BR"
            }
        },
        "openalex": {},
    },
}

add_source_world_region(document)
add_affiliation_world_regions(document)

pprint(document)
'
```

Resultado esperado:

```text
{'author_country_codes': ['BR', 'JP', 'BR'],
 'oca_data': {'openalex': {'affiliations': {'world_regions': ['Eastern Asia',
                                                              'South '
                                                              'America']}},
              'scielo': {'source': {'country_code': 'BR',
                                    'world_region': 'South America'}}}}
```

### 4. Criar um índice descartável no OpenSearch

```bash
curl --fail-with-body \
  -X PUT "http://localhost:9200/world-regions-test" \
  -H "Content-Type: application/json" \
  --data-binary '{
    "mappings": {
      "properties": {
        "author_country_codes": {
          "type": "keyword"
        },
        "oca_data": {
          "properties": {
            "scielo": {
              "properties": {
                "source": {
                  "properties": {
                    "country_code": {
                      "type": "keyword"
                    },
                    "world_region": {
                      "type": "keyword"
                    }
                  }
                }
              }
            },
            "openalex": {
              "properties": {
                "affiliations": {
                  "properties": {
                    "world_regions": {
                      "type": "keyword"
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }'
```

Inserir documentos para teste:

```bash
curl --fail-with-body \
  -X POST "http://localhost:9200/world-regions-test/_bulk?refresh=true" \
  -H "Content-Type: application/x-ndjson" \
  --data-binary $'{"index":{"_id":"novo"}}\n{"author_country_codes":["BR","JP"],"oca_data":{"scielo":{"source":{"country_code":"BR"}},"openalex":{}}}\n{"index":{"_id":"incorreto"}}\n{"author_country_codes":["US"],"oca_data":{"scielo":{"source":{"country_code":"JP","world_region":"Região errada"}},"openalex":{"affiliations":{"world_regions":["Região errada"]}}}}\n'
```

### 5. Testar o modo incremental

```bash
docker compose -f local.yml run --rm django \
  python manage.py apply_world_regions_to_silver \
  --index world-regions-test \
  --slices 1 \
  --batch-size 100 \
  --requests-per-second 50
```

O comando deve retornar um task ID.

Consultar a execução:

```bash
docker compose -f local.yml run --rm django \
  python manage.py apply_world_regions_to_silver \
  --task-id NODE:TASK
```

O documento `novo` deverá receber:

```text
BR → South America
BR + JP → Eastern Asia, South America
```

O documento `incorreto` deverá permanecer inalterado no modo incremental.

### 6. Testar o modo de reparo

```bash
docker compose -f local.yml run --rm django \
  python manage.py apply_world_regions_to_silver \
  --index world-regions-test \
  --repair \
  --slices 1 \
  --batch-size 100 \
  --requests-per-second 50
```

Após a conclusão:

```text
JP → Eastern Asia
US → Northern America
```

Os valores `"Região errada"` devem ser substituídos.

### 7. Remover o índice descartável

```http
DELETE world-regions-test
```

## Algum cenário de contexto que queira dar?

O índice de produção possui aproximadamente 75 milhões de documentos e utiliza o mapping silver anterior a este PR.

Por isso, o preenchimento:

- é assíncrono;
- possui controle de carga;
- pode usar slices paralelos;
- pode ser acompanhado ou cancelado;
- é incremental por padrão;
- não modifica o mapping automaticamente.

### Orientação obrigatória para implantação

O mapping deve ser atualizado antes do deploy e antes de liberar workers com o código novo:

```http
PUT silver_scientific_production/_mapping
{
  "properties": {
    "oca_data": {
      "properties": {
        "scielo": {
          "properties": {
            "source": {
              "properties": {
                "world_region": {
                  "type": "keyword"
                }
              }
            }
          }
        },
        "openalex": {
          "properties": {
            "affiliations": {
              "properties": {
                "world_regions": {
                  "type": "keyword"
                }
              }
            }
          }
        }
      }
    }
  }
}
```

Verificar o resultado:

```http
GET silver_scientific_production/_mapping/field/oca_data.scielo.source.world_region,oca_data.openalex.affiliations.world_regions
```

Os dois campos devem existir como `keyword` em todos os índices retornados.

Ordem da implantação:

1. Atualizar o mapping.
2. Verificar os dois campos.
3. Fazer o deploy.
4. Liberar os workers.
5. Iniciar o preenchimento incremental.
6. Acompanhar a task.

O modo `--repair` não é necessário no primeiro preenchimento. Ele deve ser reservado para corrigir ou recalcular valores já existentes.

## Screenshots
N/A

## Quais são os tickets relevantes?
#710 e PR arquivado #744 

## Referências

- [[Nações Unidas — classificação geográfica M49](https://unstats.un.org/unsd/methodology/m49/overview/)](https://unstats.un.org/unsd/methodology/m49/overview/)
- [[OpenSearch — Update by Query API](https://docs.opensearch.org/latest/api-reference/document-apis/update-by-query/)](https://docs.opensearch.org/latest/api-reference/document-apis/update-by-query/)
- [[country-converter](https://pypi.org/project/country-converter/)](https://pypi.org/project/country-converter/)
- ISO 3166-1 alpha-2 para identificação dos países

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**

- [ ] Sim — descreva os controles de proteção aplicados:
- [x] Não

Os novos campos representam regiões geográficas agregadas de fontes e afiliações institucionais. Não são adicionados dados pessoais.

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**

- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**

- [x] Sim — adiciona `country_converter==1.3.2`.
  - [ ] Verificado e aprovado no SBOM/Trivy.
  - [x] Pendente — validar no pipeline de segurança antes da aprovação do PR.
- [ ] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**

- [ ] Sim — link do job:
- [ ] Não aplicável a este PR.
- [x] Pendente — preencher após a execução do pipeline do PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**

- [ ] Sim
- [x] Não

O PR utiliza um script Painless estático no OpenSearch. O mapa país → região é enviado por `params`, sem interpolação de entrada externa no código do script.

**Este PR expõe novos endpoints, telas ou serviços?**

- [ ] Sim
- [x] Não

O PR adiciona apenas um comando administrativo interno e novos campos nos filtros existentes.

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**

- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)