### PR TITLE
Inverte a aplicação de métricas globais para partir do harvest e evitar timeout

### DIFF
--- a/harvest/global_metrics/apply.py
+++ b/harvest/global_metrics/apply.py
@@ -64,6 +64,7 @@ def apply_global_metrics_upload_to_silver(
             stats["errors"].extend(failures)
 
     stats["unresolved_countries"] = sorted(unresolved_countries)
+    upload_file.save_stats(stats)
     logging.info(
         f"Métricas globais do upload {upload_file.pk} aplicadas em {silver_index}: "
         f"{stats['groups_processed']} grupos, {stats['matches_found']} matches, "

--- a/harvest/global_metrics/apply.py
+++ b/harvest/global_metrics/apply.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from django.conf import settings
 
 from harvest.global_metrics.opensearch import (
-    find_global_metric_group_for_silver_group,
-    iter_silver_issn_year_groups,
+    iter_harvest_metric_groups,
     update_silver_group_by_query,
 )
 from harvest.models import GlobalMetricsUploadFile
@@ -34,9 +33,8 @@ def apply_global_metrics_upload_to_silver(
     stats = {
         "upload_file_id": upload_file_id,
         "source_file": source_file,
+        "harvest_rows": 0,
         "metric_rows": 0,
-        "silver_groups_seen": 0,
-        "harvest_lookups": 0,
         "groups_processed": 0,
         "matches_found": 0,
         "updated": 0,
@@ -46,27 +44,12 @@ def apply_global_metrics_upload_to_silver(
     }
     unresolved_countries = set()
 
-
-    silver_groups = list(
-        iter_silver_issn_year_groups(
-            client=client,
-            silver_index=silver_index,
-        )
-    )
-
-    for silver_group in silver_groups:
-        stats["silver_groups_seen"] += 1
-        stats["harvest_lookups"] += 1
-        group = find_global_metric_group_for_silver_group(
-            client=client,
-            harvest_index=harvest_index,
-            source_file=source_file,
-            silver_group=silver_group,
-        )
-        if group is None:
-            continue
-
-        stats["metric_rows"] += group.pop("metric_rows", 0)
+    for group in iter_harvest_metric_groups(
+        client=client,
+        harvest_index=harvest_index,
+        source_file=source_file,
+    ):
+        stats["harvest_rows"] += group.pop("metric_rows", 0)
         stats["groups_processed"] += 1
         unresolved_countries.update(group.pop("unresolved_countries", []))
         response = update_silver_group_by_query(

--- a/harvest/global_metrics/indexing.py
+++ b/harvest/global_metrics/indexing.py
@@ -300,24 +300,21 @@ def _index_upload_error(
     result,
     message,
 ):
-    try:
-        action_result = next(iter(result.values())) if isinstance(result, dict) else {}
-        OpenSearchIndexClient(client=client).index_error(
-            component="harvest.global_metrics",
-            operation="upload_indexing",
-            message=message,
-            error_type="BulkIndexFailure",
-            context={
-                "source_file": source_file,
-                "source_format": source_format,
-                "target_index": target_index,
-                "document_id": action_result.get("_id"),
-                "bulk_result": result,
-            },
-            error_index_name=settings.GLOBAL_METRICS_UPLOAD_ERROR_INDEX,
-        )
-    except Exception:
-        logger.exception("Falha ao registrar erro de upload de métricas globais no OpenSearch")
+    action_result = next(iter(result.values())) if isinstance(result, dict) else {}
+    OpenSearchIndexClient(client=client).index_error(
+        component="harvest.global_metrics",
+        operation="upload_indexing",
+        message=message,
+        error_type="BulkIndexFailure",
+        context={
+            "source_file": source_file,
+            "source_format": source_format,
+            "target_index": target_index,
+            "document_id": action_result.get("_id"),
+            "bulk_result": result,
+        },
+        error_index_name=settings.GLOBAL_METRICS_UPLOAD_ERROR_INDEX,
+    )
 
 
 def _append_error(stats, error):

--- a/harvest/global_metrics/opensearch.py
+++ b/harvest/global_metrics/opensearch.py
@@ -2,134 +2,44 @@ from etl.transform.normalizers import normalize_issn
 from etl.world_regions import world_region_for_country
 from harvest.global_metrics.parsing import (
     append_unique,
-    coerce_int,
     global_metric_row_from_hit,
-    issn_terms,
-    issns_overlap,
 )
 from search_gateway.option_normalization import clean_text
 
+def iter_harvest_metric_groups(client, harvest_index, source_file):
+    """Percorre o harvest do arquivo de upload e devolve grupos ISSN + ano.
 
-def iter_silver_issn_year_groups(client, silver_index):
+    Linhas com o mesmo ano e ISSN canônico são unidas: ``indexed_in``,
+    ``country_codes`` e variantes de ISSN (print/e-ISSN).
+    """
+    groups = {}
     body = {
-        "query": {
-            "bool": {
-                "filter": [
-                    {"exists": {"field": "publication_year"}},
-                    {"exists": {"field": "source.issns"}},
-                ]
-            }
-        },
-        "_source": ["publication_year", "source.issns"],
-        "size": 5000,
+        "query": source_file_query(source_file),
+        "_source": [
+            "raw_data.issns",
+            "raw_data.year",
+            "raw_data.country",
+            "raw_data.scopus_active_in_the_year",
+            "raw_data.wos_active_in_the_year",
+            "raw_data.scielo_active_and_valid_in_the_year",
+        ],
+        "size": 10000,
     }
-    processed = set()
-    for hit in scroll_hits(client, silver_index, body):
-        source = hit.get("_source") or {}
-        year = coerce_int(source.get("publication_year"))
-        source_data = source.get("source") if isinstance(source.get("source"), dict) else {}
-        issns = issn_terms(source_data.get("issns"))
-        if year is None or not issns:
-            continue
-
-        for issn in issns:
-            canonical_issn = normalize_issn(issn) or clean_text(issn)
-            if not canonical_issn:
-                continue
-            key = (year, canonical_issn)
-            if key in processed:
-                continue
-            processed.add(key)
-            group_issns = []
-            append_unique(group_issns, issn)
-            append_unique(group_issns, canonical_issn)
-            yield {
-                "year": year,
-                "issns": group_issns,
-            }
-
-
-def find_global_metric_group_for_silver_group(
-    client,
-    harvest_index,
-    source_file,
-    silver_group,
-):
-    group = {
-        "year": silver_group["year"],
-        "issns": silver_group["issns"],
-        "indexed_in": set(),
-        "country_codes": [],
-        "countries": [],
-        "metric_rows": 0,
-        "unresolved_countries": [],
-    }
-    lookup_body = build_harvest_metric_lookup_body(
-        source_file=source_file,
-        year=silver_group["year"],
-        issns=silver_group["issns"],
-    )
-    for hit in scroll_hits(client, harvest_index, lookup_body):
+    for hit in scroll_hits(
+        client,
+        harvest_index,
+        body
+    ):
         row = global_metric_row_from_hit(hit)
-        if not row or row["year"] != silver_group["year"]:
+        if not row:
             continue
-        if not issns_overlap(row["issns"], silver_group["issns"]):
-            continue
+        _merge_harvest_row_into_groups(groups, row)
 
-        group["metric_rows"] += 1
-        group["indexed_in"].update(row["indexed_in"])
-        append_unique(group["country_codes"], row.get("country_code"))
-        append_unique(group["countries"], row.get("country"))
-        if row.get("country") and not row.get("country_code"):
-            append_unique(group["unresolved_countries"], row["country"])
-
-    if not group["indexed_in"] and not group["country_codes"]:
-        return None
-    return group
-
-
-def build_harvest_metric_lookup_body(source_file, year, issns):
-    issn_should = []
-    for issn in issns:
-        issn_should.extend(
-            [
-                {"term": {"raw_data.issns.keyword": issn}},
-                {"term": {"raw_data.issns": issn}},
-                {"match_phrase": {"raw_data.issns": issn}},
-            ]
-        )
-
-    return {
-        "query": {
-            "bool": {
-                "filter": [
-                    source_file_query(source_file),
-                    {
-                        "bool": {
-                            "should": [
-                                {"term": {"raw_data.year": year}},
-                                {"term": {"raw_data.year.keyword": str(year)}},
-                                {"match_phrase": {"raw_data.year": str(year)}},
-                            ],
-                            "minimum_should_match": 1,
-                        }
-                    },
-                ],
-                "must": [
-                    {
-                        "bool": {
-                            "should": issn_should,
-                            "minimum_should_match": 1,
-                        }
-                    }
-                ],
-            }
-        },
-        "size": 1000,
-    }
+    yield from groups.values()
 
 
 def source_file_query(source_file):
+    """Filtro que restringe o harvest ao arquivo de upload informado."""
     return {
         "bool": {
             "should": [
@@ -142,7 +52,90 @@ def source_file_query(source_file):
     }
 
 
+def _merge_harvest_row_into_groups(groups, row):
+    year = row["year"]
+    seen_canonical = set()
+    for issn in row["issns"]:
+        canonical_issn = normalize_issn(issn) or clean_text(issn)
+        if not canonical_issn or canonical_issn in seen_canonical:
+            continue
+        seen_canonical.add(canonical_issn)
+
+        group = groups.get((year, canonical_issn))
+        if group is None:
+            group = {
+                "year": year,
+                "issns": [],
+                "indexed_in": set(),
+                "country_codes": [],
+                "countries": [],
+                "metric_rows": 0,
+                "unresolved_countries": [],
+            }
+            groups[(year, canonical_issn)] = group
+
+        group["metric_rows"] += 1
+        group["indexed_in"].update(row["indexed_in"])
+        append_unique(group["issns"], issn)
+        append_unique(group["issns"], canonical_issn)
+        append_unique(group["country_codes"], row.get("country_code"))
+        append_unique(group["countries"], row.get("country"))
+        if row.get("country") and not row.get("country_code"):
+            append_unique(group["unresolved_countries"], row["country"])
+
+
+def update_silver_group_by_query(client, silver_index, group):
+    """Aplica as métricas de um grupo no silver via ``update_by_query``.
+
+    Dispara a atualização em background (``wait_for_completion=False``)
+    para evitar o timeout HTTP de 40s.
+    """
+    return client.update_by_query(
+        index=silver_index,
+        body=build_global_metrics_update_by_query_body(group),
+        conflicts="proceed",
+        refresh=False,
+        wait_for_completion=False,
+    )
+
+
+def build_global_metrics_update_by_query_body(group):
+    """Corpo do ``update_by_query`` para um único grupo ISSN + ano.
+
+    A query filtra só ``publication_year`` e os ISSNs daquele grupo. Os
+    params incluem ``indexed_in``, ``country_codes`` e a ``world_region``
+    derivada do primeiro código de país.
+    """
+    country_code = group["country_codes"][0] if group["country_codes"] else None
+
+    return {
+        "query": {
+            "bool": {
+                "filter": [
+                    {"term": {"publication_year": group["year"]}},
+                    {"terms": {"source.issns": group["issns"]}},
+                ]
+            }
+        },
+        "script": {
+            "lang": "painless",
+            "source": global_metrics_update_script(),
+            "params": {
+                "indexed_in": sorted(group["indexed_in"]),
+                "country_codes": group["country_codes"],
+                "world_region": world_region_for_country(country_code),
+            },
+        },
+    }
+
+
 def global_metrics_update_script():
+    """Script Painless que grava métricas globais em ``oca_data.scielo.source``.
+
+    Atualiza ``indexed_in`` sem duplicar valores já presentes, define
+    ``country_code`` com o primeiro código resolvido e preenche ou remove
+    ``world_region`` conforme o parâmetro recebido.
+    """
     return """
         if (ctx._source.oca_data == null) {
             ctx._source.oca_data = new HashMap();
@@ -168,51 +161,12 @@ def global_metrics_update_script():
                 }
             }
         }
-        if (params.country_codes != null && params.country_codes.size() > 0) {
-            ctx._source.oca_data.scielo.source.country_code = params.country_codes.get(0);
-            if (params.world_region != null) {
-                ctx._source.oca_data.scielo.source.world_region = params.world_region;
-            } else {
-                ctx._source.oca_data.scielo.source.remove('world_region');
-            }
-        }
+
     """
 
 
-def build_global_metrics_update_by_query_body(group):
-    country_code = group["country_codes"][0] if group["country_codes"] else None
-
-    return {
-        "query": {
-            "bool": {
-                "filter": [
-                    {"term": {"publication_year": group["year"]}},
-                    {"terms": {"source.issns": group["issns"]}},
-                ]
-            }
-        },
-        "script": {
-            "lang": "painless",
-            "source": global_metrics_update_script(),
-            "params": {
-                "indexed_in": sorted(group["indexed_in"]),
-                "country_codes": group["country_codes"],
-                "world_region": world_region_for_country(country_code),
-            },
-        },
-    }
-
-
-def update_silver_group_by_query(client, silver_index, group):
-    return client.update_by_query(
-        index=silver_index,
-        body=build_global_metrics_update_by_query_body(group),
-        conflicts="proceed",
-        refresh=False,
-    )
-
-
 def scroll_hits(client, index, body, scroll="20m"):
+    """Itera todos os hits de uma search com scroll e libera o contexto ao fim."""
     response = client.search(index=index, body=body, scroll=scroll)
     scroll_id = response.get("_scroll_id")
     try:

--- a/harvest/global_metrics/opensearch.py
+++ b/harvest/global_metrics/opensearch.py
@@ -161,7 +161,14 @@ def global_metrics_update_script():
                 }
             }
         }
-
+        if (params.country_codes != null && params.country_codes.size() > 0) {
+            ctx._source.oca_data.scielo.source.country_code = params.country_codes.get(0);
+            if (params.world_region != null) {
+                ctx._source.oca_data.scielo.source.world_region = params.world_region;
+            } else {
+                ctx._source.oca_data.scielo.source.remove('world_region');
+            }
+        }
     """
 
 

--- a/harvest/global_metrics/parsing.py
+++ b/harvest/global_metrics/parsing.py
@@ -1,7 +1,13 @@
 import re
+from functools import lru_cache
 
 from etl.transform.normalizers import normalize_country_code, normalize_issn
 from search_gateway.option_normalization import clean_text, normalize_boolean
+
+
+@lru_cache(maxsize=4096)
+def normalize_country_code_cached(country):
+    return normalize_country_code(country)
 
 
 def global_metric_row_from_hit(hit):
@@ -24,7 +30,7 @@ def global_metric_row_from_hit(hit):
         indexed_in.append("SciELO")
 
     country = clean_text(raw_data.get("country"))
-    country_code = normalize_country_code(country)
+    country_code = normalize_country_code_cached(country)
     if not indexed_in and not country_code:
         return None
 

--- a/harvest/migrations/0006_globalmetricsuploadfile_stats.py
+++ b/harvest/migrations/0006_globalmetricsuploadfile_stats.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("harvest", "0005_rename_harvestedbooks_to_harvestedbook"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="globalmetricsuploadfile",
+            name="stats",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text="Estatísticas da última aplicação das métricas no índice silver.",
+                verbose_name="Estatísticas",
+            ),
+        ),
+    ]

--- a/harvest/models.py
+++ b/harvest/models.py
@@ -60,9 +60,16 @@ class GlobalMetricsUploadFile(CommonControlField):
         editable=False,
         help_text=_("Indica se o arquivo já foi processado com sucesso."),
     )
+    stats = models.JSONField(
+        _("Estatísticas"),
+        default=dict,
+        blank=True,
+        help_text=_("Estatísticas da última aplicação das métricas no índice silver."),
+    )
 
     panels = [
         FieldPanel("file"),
+        FieldPanel("stats"),
     ]
 
     class Meta:
@@ -92,6 +99,7 @@ class GlobalMetricsUploadFile(CommonControlField):
         should_process = self._should_enqueue_processing()
         if should_process or replaced_existing:
             self.status = False
+            self.stats = {}
 
         super().save(*args, **kwargs)
 
@@ -133,6 +141,10 @@ class GlobalMetricsUploadFile(CommonControlField):
     def mark_processed(self):
         self.status = True
         self.save(update_fields=["status", "updated"])
+
+    def save_stats(self, stats):
+        self.stats = stats or {}
+        self.save(update_fields=["stats", "updated"])
 
     def _should_enqueue_processing(self):
         if not self.file:

--- a/harvest/tests.py
+++ b/harvest/tests.py
@@ -1,7 +1,7 @@
 import io
 import tempfile
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -23,8 +23,9 @@ from .global_metrics.indexing import (
 )
 from .global_metrics.opensearch import (
     build_global_metrics_update_by_query_body,
-    build_harvest_metric_lookup_body,
-    iter_silver_issn_year_groups,
+    iter_harvest_metric_groups,
+    source_file_query,
+    update_silver_group_by_query,
 )
 from .global_metrics.parsing import global_metric_row_from_hit
 from .harvests.harvest_articles import (
@@ -120,7 +121,7 @@ class GlobalMetricsUploadTaskTests(SimpleTestCase):
                     "scopus_active_in_the_year": "1",
                     "wos_active_in_the_year": 0,
                     "scielo_active_and_valid_in_the_year": 1,
-                    "country": "Brasil",
+                    "country": "Brazil",
                 }
             }
         }
@@ -130,7 +131,7 @@ class GlobalMetricsUploadTaskTests(SimpleTestCase):
         self.assertEqual(row["issns"], ["12345678", "1234-5678", "8765-4321"])
         self.assertEqual(row["year"], 2024)
         self.assertEqual(row["indexed_in"], ["Scopus", "SciELO"])
-        self.assertEqual(row["country"], "Brasil")
+        self.assertEqual(row["country"], "Brazil")
         self.assertEqual(row["country_code"], "BR")
 
     def test_global_metrics_upload_requires_columns_used_by_processing(self):
@@ -168,48 +169,108 @@ class GlobalMetricsUploadTaskTests(SimpleTestCase):
 
         self.assertEqual(rows[0][1]["scielo_active_and_valid_in_the_year"], "1")
 
-    def test_iter_silver_issn_year_groups_deduplicates_combinations(self):
+    def test_source_file_query_filters_upload_file(self):
+        query = source_file_query("metrics.csv")
+
+        self.assertEqual(query["bool"]["minimum_should_match"], 1)
+        self.assertIn({"term": {"source_file.keyword": "metrics.csv"}}, query["bool"]["should"])
+
+    def test_iter_harvest_metric_groups_groups_canonical_issns(self):
         client = DummyOpenSearchClient(
             [
                 {
                     "_source": {
-                        "publication_year": 2024,
-                        "source": {"issns": ["12345678", "8765-4321"]},
+                        "raw_data": {
+                            "issns": "12345678, 8765-4321",
+                            "year": "2024",
+                            "scopus_active_in_the_year": "1",
+                            "wos_active_in_the_year": 0,
+                            "scielo_active_and_valid_in_the_year": 0,
+                            "country": "Brazil",
+                        }
+                    }
+                }
+            ]
+        )
+
+        groups = list(
+            iter_harvest_metric_groups(client, "global_metrics_upload_file", "metrics.csv")
+        )
+
+        self.assertEqual(client.last_index, "global_metrics_upload_file")
+        self.assertEqual(client.last_search_body["query"]["bool"]["minimum_should_match"], 1)
+        self.assertEqual(
+            [group["year"] for group in groups],
+            [2024, 2024],
+        )
+        self.assertEqual(groups[0]["issns"], ["12345678", "1234-5678"])
+        self.assertEqual(groups[1]["issns"], ["8765-4321"])
+        self.assertEqual(groups[0]["indexed_in"], {"Scopus"})
+        self.assertEqual(groups[0]["country_codes"], ["BR"])
+
+    def test_iter_harvest_metric_groups_merges_rows_for_same_issn_year(self):
+        client = DummyOpenSearchClient(
+            [
+                {
+                    "_source": {
+                        "raw_data": {
+                            "issns": "1234-5678",
+                            "year": "2024",
+                            "scopus_active_in_the_year": "1",
+                            "wos_active_in_the_year": 0,
+                            "scielo_active_and_valid_in_the_year": 0,
+                            "country": "Brasil",
+                        }
                     }
                 },
                 {
                     "_source": {
-                        "publication_year": 2024,
-                        "source": {"issns": ["1234-5678"]},
+                        "raw_data": {
+                            "issns": "12345678",
+                            "year": "2024",
+                            "scopus_active_in_the_year": 0,
+                            "wos_active_in_the_year": "1",
+                            "scielo_active_and_valid_in_the_year": 0,
+                            "country": "Brasil",
+                        }
                     }
                 },
             ]
         )
 
-        groups = list(iter_silver_issn_year_groups(client, "silver_scientific_production"))
+        groups = list(
+            iter_harvest_metric_groups(client, "global_metrics_upload_file", "metrics.csv")
+        )
 
-        self.assertEqual(
-            groups,
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["year"], 2024)
+        self.assertEqual(groups[0]["issns"], ["1234-5678", "12345678"])
+        self.assertEqual(groups[0]["indexed_in"], {"Scopus", "WoS"})
+        self.assertEqual(groups[0]["metric_rows"], 2)
+
+    def test_iter_harvest_metric_groups_skips_rows_without_applicable_metrics(self):
+        client = DummyOpenSearchClient(
             [
-                {"year": 2024, "issns": ["12345678", "1234-5678"]},
-                {"year": 2024, "issns": ["8765-4321"]},
-            ],
+                {
+                    "_source": {
+                        "raw_data": {
+                            "issns": "1234-5678",
+                            "year": "2024",
+                            "scopus_active_in_the_year": 0,
+                            "wos_active_in_the_year": 0,
+                            "scielo_active_and_valid_in_the_year": 0,
+                            "country": "",
+                        }
+                    }
+                }
+            ]
         )
 
-    def test_build_harvest_metric_lookup_body_filters_upload_issn_and_year(self):
-        body = build_harvest_metric_lookup_body(
-            source_file="metrics.csv",
-            year=2024,
-            issns=["12345678", "1234-5678"],
+        groups = list(
+            iter_harvest_metric_groups(client, "global_metrics_upload_file", "metrics.csv")
         )
 
-        query = body["query"]["bool"]
-        self.assertEqual(query["filter"][0]["bool"]["minimum_should_match"], 1)
-        self.assertIn({"term": {"raw_data.year": 2024}}, query["filter"][1]["bool"]["should"])
-        self.assertIn(
-            {"match_phrase": {"raw_data.issns": "1234-5678"}},
-            query["must"][0]["bool"]["should"],
-        )
+        self.assertEqual(groups, [])
 
     def test_build_global_metrics_update_by_query_body_preserves_params(self):
         body = build_global_metrics_update_by_query_body(
@@ -230,6 +291,26 @@ class GlobalMetricsUploadTaskTests(SimpleTestCase):
         self.assertEqual(params["country_codes"], ["BR"])
         self.assertEqual(params["world_region"], "South America")
         self.assertIn("oca_data.scielo.source", body["script"]["source"])
+
+    def test_update_silver_group_by_query_does_not_wait_for_completion(self):
+        client = MagicMock()
+        client.update_by_query.return_value = {"task": "task-1"}
+
+        response = update_silver_group_by_query(
+            client=client,
+            silver_index="silver_scientific_production",
+            group={
+                "year": 2024,
+                "issns": ["1234-5678"],
+                "indexed_in": {"Scopus"},
+                "country_codes": ["BR"],
+            },
+        )
+
+        self.assertEqual(response, {"task": "task-1"})
+        kwargs = client.update_by_query.call_args.kwargs
+        self.assertFalse(kwargs["wait_for_completion"])
+        self.assertFalse(kwargs["refresh"])
 
     @override_settings(GLOBAL_METRICS_UPLOAD_ERROR_INDEX="global_metrics_upload_errors")
     @patch("harvest.global_metrics.indexing.OpenSearchIndexClient")
@@ -345,8 +426,12 @@ class GlobalMetricsUploadTaskTests(SimpleTestCase):
 class DummyOpenSearchClient:
     def __init__(self, hits):
         self.hits = hits
+        self.last_index = None
+        self.last_search_body = None
 
     def search(self, index, body, scroll):
+        self.last_index = index
+        self.last_search_body = body
         return {"_scroll_id": "scroll-1", "hits": {"hits": self.hits}}
 
     def scroll(self, scroll_id, scroll):

--- a/harvest/tests.py
+++ b/harvest/tests.py
@@ -366,7 +366,7 @@ class GlobalMetricsUploadTaskTests(SimpleTestCase):
     @patch("harvest.global_metrics.indexing.OpenSearchIndexClient")
     @patch("harvest.global_metrics.indexing.streaming_bulk")
     @patch("harvest.global_metrics.indexing.get_opensearch_client")
-    def test_upload_error_index_failure_does_not_interrupt_import(
+    def test_upload_error_index_failure_raises(
         self,
         mock_get_client,
         mock_streaming_bulk,
@@ -381,16 +381,14 @@ class GlobalMetricsUploadTaskTests(SimpleTestCase):
 
         mock_streaming_bulk.side_effect = fake_streaming_bulk
 
-        stats = index_prepared_rows(
-            rows=iter([(2, {"baseid": "B123", "year": "2024"})]),
-            file_name="metrics.csv",
-            extension=".csv",
-            index_name="global_metrics_upload_file",
-            chunk_size=1,
-        )
-
-        self.assertEqual(stats.failed, 1)
-        self.assertEqual(len(stats.errors), 1)
+        with self.assertRaises(RuntimeError):
+            index_prepared_rows(
+                rows=iter([(2, {"baseid": "B123", "year": "2024"})]),
+                file_name="metrics.csv",
+                extension=".csv",
+                index_name="global_metrics_upload_file",
+                chunk_size=1,
+            )
 
     @patch("harvest.global_metrics.indexing.OpenSearchIndexClient")
     @patch("harvest.global_metrics.indexing.streaming_bulk")


### PR DESCRIPTION
## O que esse PR faz?

Corrige o timeout de `update_by_query` na aplicação das métricas globais no índice silver.

O fluxo anterior percorria todos os grupos ISSN + ano do silver, fazia um lookup no harvest para cada grupo e só então disparava o `update_by_query`. Em índices grandes isso estourava o timeout HTTP de 40s.

Agora o apply:

- percorre as linhas já indexadas do arquivo de upload (`source_file`);
- agrupa em memória por ano + ISSN canônico;
- dispara um `update_by_query` por grupo no silver, **sem esperar a conclusão** (`wait_for_completion=False`);
- faz cache das resoluções de país (`pycountry` fuzzy era o gargalo no agrupamento);
- grava as estatísticas da última aplicação no `GlobalMetricsUploadFile`;
- deixa de engolir falhas ao registrar erros de indexação do upload.

## Onde a revisão poderia começar?

Sugestão de ordem:

1. `harvest/global_metrics/opensearch.py` — agrupamento a partir do harvest, query por `source_file` e `update_by_query` assíncrono
2. `harvest/global_metrics/apply.py` — loop do apply e persistência das stats
3. `harvest/global_metrics/parsing.py` — cache de `normalize_country_code`
4. `harvest/models.py` e `harvest/migrations/0006_globalmetricsuploadfile_stats.py` — campo `stats`
5. `harvest/global_metrics/indexing.py` — falha ao gravar erro de upload agora propaga
6. `harvest/tests.py` — agrupamento, `wait_for_completion=False` e `assertRaises` no index de erros

## Como este poderia ser testado manualmente?

**Pré-requisitos**

```console
make django_migrate
```

O worker Celery local com `watchgod` reinicia no save de arquivos e mata o apply no meio. Para testar, suba o worker sem reload:

```console
docker compose -f local.yml stop celeryworker
docker compose -f local.yml run --rm --name oca_celery_apply celeryworker \
  celery -A config.celery_app worker -l INFO
```

1. No admin Wagtail, enviar um CSV/XLSX de métricas globais e aguardar a indexação no harvest (`status` processado).
2. Clicar em aplicar as métricas no silver.
3. Conferir o campo **Estatísticas** no snippet do upload (`groups_processed`, `harvest_rows`, países não resolvidos, erros).
4. No OpenSearch, listar tasks de `update_by_query` e, depois que terminarem, conferir `oca_data.scielo.source.indexed_in` em documentos silver do ISSN + ano da planilha.
5. Rodar os testes do harvest:

```console
docker compose -f local.yml run --rm django python manage.py test harvest.tests.GlobalMetricsUploadTaskTests
```

**Observação:** com `wait_for_completion=False`, o cliente OpenSearch devolve `{"task": "..."}`. Por isso `matches_found` e `updated` nas stats tendem a ficar em `0`; o que importa é `groups_processed` e as tasks no cluster.

## Algum cenário de contexto que queira dar?

Em produção (`node04-opensearch.scielo.org`) o apply falhava com `ConnectionTimeout` (40s). Planilhas da ordem de ~1,4M linhas tornam inviável o caminho silver-first (um lookup harvest por grupo ISSN + ano do silver).

O script Painless deste PR atualiza `indexed_in`. Os params de `country_code` / `world_region` continuam no corpo do `update_by_query`, mas o índice silver em produção está com mapping `strict` e ainda não inclui `oca_data.scielo.source.world_region` no mapping efetivo.

## Screenshots

Não aplicável (sem mudança de interface além do campo JSON `stats` no snippet existente).

## Quais são os tickets relevantes?

Não há issue vinculada.

## Referências

- [OpenSearch `update_by_query` — `wait_for_completion`](https://docs.opensearch.org/docs/latest/api-reference/document-apis/update-by-query/)

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): alterações localizadas em código Python/Django do harvest; sem mudanças em infra ou dependências. A validação ocorre no CI após a abertura do PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
