### PR TITLE
Aguarda as tasks de update_by_query ao aplicar métricas globais

### DIFF
--- a/harvest/global_metrics/apply.py
+++ b/harvest/global_metrics/apply.py
@@ -18,6 +18,10 @@ def apply_global_metrics_upload_to_silver(
 ):
 
     upload_file = GlobalMetricsUploadFile.objects.get(pk=upload_file_id)
+    if not upload_file.status:
+        raise RuntimeError(
+            "O arquivo de métricas globais ainda não foi processado."
+        )
     client = get_opensearch_client()
     if client is None:
         raise RuntimeError("Cliente OpenSearch não configurado.")

--- a/harvest/global_metrics/apply.py
+++ b/harvest/global_metrics/apply.py
@@ -2,10 +2,12 @@ import logging
 from pathlib import Path
 
 from django.conf import settings
+from django.db import close_old_connections
 
 from harvest.global_metrics.opensearch import (
     iter_harvest_metric_groups,
     update_silver_group_by_query,
+    wait_for_update_task,
 )
 from harvest.models import GlobalMetricsUploadFile
 from search_gateway.client import get_opensearch_client
@@ -33,12 +35,15 @@ def apply_global_metrics_upload_to_silver(
         "silver_scientific_production",
     )
     source_file = Path(upload_file.file.name).name
+    logging.info(
+        f"Arquivo de métricas globais {upload_file.pk} ({source_file}) já foi processado; "
+        f"iniciando update no índice silver {silver_index}."
+    )
 
     stats = {
         "upload_file_id": upload_file_id,
         "source_file": source_file,
         "harvest_rows": 0,
-        "metric_rows": 0,
         "groups_processed": 0,
         "matches_found": 0,
         "updated": 0,
@@ -48,24 +53,34 @@ def apply_global_metrics_upload_to_silver(
     }
     unresolved_countries = set()
 
-    for group in iter_harvest_metric_groups(
-        client=client,
-        harvest_index=harvest_index,
-        source_file=source_file,
-    ):
-        stats["harvest_rows"] += group.pop("metric_rows", 0)
-        stats["groups_processed"] += 1
-        unresolved_countries.update(group.pop("unresolved_countries", []))
-        response = update_silver_group_by_query(
+    try:
+        groups = iter_harvest_metric_groups(
             client=client,
-            silver_index=silver_index,
-            group=group,
+            harvest_index=harvest_index,
+            source_file=source_file,
         )
-        stats["matches_found"] += response.get("total", 0)
-        stats["updated"] += response.get("updated", 0)
-        stats["version_conflicts"] += response.get("version_conflicts", 0)
-        if failures := response.get("failures"):
-            stats["errors"].extend(failures)
+        for group in groups:
+            stats["harvest_rows"] += group.pop("metric_rows", 0)
+            unresolved_countries.update(group.pop("unresolved_countries", []))
+            submission = update_silver_group_by_query(
+                client=client,
+                silver_index=silver_index,
+                group=group,
+            )
+            task_id = submission.get("task")
+            if not task_id:
+                raise RuntimeError(
+                    "OpenSearch não retornou o ID da task de update_by_query."
+                )
+            response = wait_for_update_task(client, task_id)
+            stats["groups_processed"] += 1
+            stats["matches_found"] += response.get("total", 0)
+            stats["updated"] += response.get("updated", 0)
+            stats["version_conflicts"] += response.get("version_conflicts", 0)
+            if failures := response.get("failures"):
+                stats["errors"].extend(failures)
+    finally:
+        close_old_connections()
 
     stats["unresolved_countries"] = sorted(unresolved_countries)
     upload_file.save_stats(stats)

--- a/harvest/global_metrics/opensearch.py
+++ b/harvest/global_metrics/opensearch.py
@@ -11,7 +11,7 @@ from harvest.global_metrics.parsing import (
 )
 from search_gateway.option_normalization import clean_text
 
-_RETRY_DELAYS = (2, 5, 10)
+_RETRY_DELAYS = (3**2, 3**3, 3**4, 3**5)
 
 
 def iter_harvest_metric_groups(client, harvest_index, source_file):

--- a/harvest/global_metrics/opensearch.py
+++ b/harvest/global_metrics/opensearch.py
@@ -1,6 +1,7 @@
+import logging
 import time
 
-from opensearchpy.exceptions import NotFoundError
+from opensearchpy.exceptions import NotFoundError, TransportError
 
 from etl.transform.normalizers import normalize_issn
 from etl.world_regions import world_region_for_country
@@ -9,6 +10,9 @@ from harvest.global_metrics.parsing import (
     global_metric_row_from_hit,
 )
 from search_gateway.option_normalization import clean_text
+
+_RETRY_DELAYS = (2, 5, 10)
+
 
 def iter_harvest_metric_groups(client, harvest_index, source_file):
     """Percorre o harvest do arquivo de upload e devolve grupos ISSN + ano.
@@ -92,15 +96,31 @@ def update_silver_group_by_query(client, silver_index, group):
     """Aplica as métricas de um grupo no silver via ``update_by_query``.
 
     Dispara a atualização em background (``wait_for_completion=False``)
-    para evitar o timeout HTTP de 40s.
+    para evitar o timeout HTTP de 40s. Retenta em 429 para não abortar
+    o apply quando o cluster recusa a task.
     """
-    return client.update_by_query(
-        index=silver_index,
-        body=build_global_metrics_update_by_query_body(group),
-        conflicts="proceed",
-        refresh=False,
-        wait_for_completion=False,
-    )
+    params = {
+        "index": silver_index,
+        "body": build_global_metrics_update_by_query_body(group),
+        "conflicts": "proceed",
+        "refresh": False,
+        "wait_for_completion": False,
+    }
+
+    for attempt in range(len(_RETRY_DELAYS) + 1):
+        try:
+            return client.update_by_query(**params)
+        except TransportError as exc:
+            status = getattr(exc, "status_code", None)
+            if status is None and exc.args:
+                status = exc.args[0]
+            if status != 429 or attempt == len(_RETRY_DELAYS):
+                raise
+            delay = _RETRY_DELAYS[attempt]
+            logging.warning(
+                f"OpenSearch recusou update_by_query com 429; nova tentativa em {delay}s."
+            )
+            time.sleep(delay)
 
 
 def wait_for_update_task(client, task_id, poll_interval=1):

--- a/harvest/global_metrics/opensearch.py
+++ b/harvest/global_metrics/opensearch.py
@@ -1,3 +1,7 @@
+import time
+
+from opensearchpy.exceptions import NotFoundError
+
 from etl.transform.normalizers import normalize_issn
 from etl.world_regions import world_region_for_country
 from harvest.global_metrics.parsing import (
@@ -97,6 +101,26 @@ def update_silver_group_by_query(client, silver_index, group):
         refresh=False,
         wait_for_completion=False,
     )
+
+
+def wait_for_update_task(client, task_id, poll_interval=1):
+    """Aguarda uma task de ``update_by_query`` e devolve sua resposta."""
+    while True:
+        try:
+            result = client.tasks.get(task_id=task_id)
+        except NotFoundError as exc:
+            raise RuntimeError(
+                f"Task OpenSearch {task_id} não encontrada."
+            ) from exc
+
+        if not result.get("completed"):
+            time.sleep(poll_interval)
+            continue
+        if error := result.get("error"):
+            raise RuntimeError(
+                f"Task OpenSearch {task_id} falhou: {error}"
+            )
+        return result.get("response", {})
 
 
 def build_global_metrics_update_by_query_body(group):

--- a/harvest/global_metrics/process.py
+++ b/harvest/global_metrics/process.py
@@ -11,6 +11,19 @@ def process_global_metrics_upload_file(upload_file_id, index_name=None, chunk_si
     from harvest.models import GlobalMetricsUploadFile
 
     upload_file = GlobalMetricsUploadFile.objects.get(pk=upload_file_id)
+    if upload_file.status:
+        logging.info(
+            "Arquivo de métricas globais %s já foi processado; "
+            "reindexação ignorada.",
+            upload_file.pk,
+        )
+        return {
+            "skipped": True,
+            "rows_read": 0,
+            "indexed": 0,
+            "failed": 0,
+            "errors": [],
+        }
 
     with upload_file.file.open("rb") as file_obj:
         stats = index_file_obj(

--- a/harvest/global_metrics/process.py
+++ b/harvest/global_metrics/process.py
@@ -13,10 +13,9 @@ def process_global_metrics_upload_file(upload_file_id, index_name=None, chunk_si
     upload_file = GlobalMetricsUploadFile.objects.get(pk=upload_file_id)
     if upload_file.status:
         logging.info(
-            "Arquivo de métricas globais %s já foi processado; "
-            "reindexação ignorada.",
-            upload_file.pk,
+            f"Arquivo de métricas globais {upload_file.pk} já foi processado; reindexação ignorada."
         )
+
         return {
             "skipped": True,
             "rows_read": 0,

--- a/harvest/tests.py
+++ b/harvest/tests.py
@@ -335,6 +335,31 @@ class GlobalMetricsUploadTaskTests(SimpleTestCase):
         self.assertFalse(kwargs["refresh"])
 
     @patch("harvest.global_metrics.opensearch.time.sleep")
+    def test_update_silver_group_by_query_retries_on_429(self, mock_sleep):
+        from opensearchpy.exceptions import TransportError
+
+        client = MagicMock()
+        client.update_by_query.side_effect = [
+            TransportError(429, "circuit_breaking_exception", "too large"),
+            {"task": "task-2"},
+        ]
+
+        response = update_silver_group_by_query(
+            client=client,
+            silver_index="silver_scientific_production",
+            group={
+                "year": 2024,
+                "issns": ["1234-5678"],
+                "indexed_in": {"Scopus"},
+                "country_codes": ["BR"],
+            },
+        )
+
+        self.assertEqual(response, {"task": "task-2"})
+        self.assertEqual(client.update_by_query.call_count, 2)
+        mock_sleep.assert_called()
+
+    @patch("harvest.global_metrics.opensearch.time.sleep")
     def test_wait_for_update_task_returns_completed_response(self, mock_sleep):
         client = MagicMock()
         client.tasks.get.side_effect = [

--- a/harvest/tests.py
+++ b/harvest/tests.py
@@ -27,6 +27,7 @@ from .global_metrics.opensearch import (
     iter_harvest_metric_groups,
     source_file_query,
     update_silver_group_by_query,
+    wait_for_update_task,
 )
 from .global_metrics.parsing import global_metric_row_from_hit
 from .harvests.harvest_articles import (
@@ -332,6 +333,44 @@ class GlobalMetricsUploadTaskTests(SimpleTestCase):
         kwargs = client.update_by_query.call_args.kwargs
         self.assertFalse(kwargs["wait_for_completion"])
         self.assertFalse(kwargs["refresh"])
+
+    @patch("harvest.global_metrics.opensearch.time.sleep")
+    def test_wait_for_update_task_returns_completed_response(self, mock_sleep):
+        client = MagicMock()
+        client.tasks.get.side_effect = [
+            {"completed": False},
+            {
+                "completed": True,
+                "response": {"total": 3, "updated": 2},
+            },
+        ]
+
+        response = wait_for_update_task(client, "t1", poll_interval=0.1)
+
+        self.assertEqual(response, {"total": 3, "updated": 2})
+        mock_sleep.assert_called_once_with(0.1)
+
+    def test_wait_for_update_task_raises_when_task_is_missing(self):
+        from opensearchpy.exceptions import NotFoundError
+
+        client = MagicMock()
+        client.tasks.get.side_effect = NotFoundError(404, "not found", {})
+
+        with self.assertRaisesMessage(RuntimeError, "gone"):
+            wait_for_update_task(client, "gone")
+
+    def test_wait_for_update_task_raises_on_task_error(self):
+        client = MagicMock()
+        client.tasks.get.return_value = {
+            "completed": True,
+            "error": {"type": "circuit_breaking_exception"},
+        }
+
+        with self.assertRaisesMessage(
+            RuntimeError,
+            "circuit_breaking_exception",
+        ):
+            wait_for_update_task(client, "failed-task")
 
     @override_settings(GLOBAL_METRICS_UPLOAD_ERROR_INDEX="global_metrics_upload_errors")
     @patch("harvest.global_metrics.indexing.OpenSearchIndexClient")

--- a/harvest/tests.py
+++ b/harvest/tests.py
@@ -21,6 +21,7 @@ from .global_metrics.indexing import (
     index_prepared_rows,
     iter_file_rows,
 )
+from .global_metrics.process import process_global_metrics_upload_file
 from .global_metrics.opensearch import (
     build_global_metrics_update_by_query_body,
     iter_harvest_metric_groups,
@@ -103,6 +104,26 @@ class GlobalMetricsUploadFileTests(TestCase):
                 with second.file.open("rb") as stored_file:
                     self.assertEqual(stored_file.read(), b"second-version")
                 self.assertEqual(mock_delay.call_count, 2)
+
+    @patch("harvest.global_metrics.process.index_file_obj")
+    @patch("harvest.tasks.process_global_metrics_upload_file.delay")
+    def test_process_skips_reindex_when_already_processed(self, mock_delay, mock_index):
+        with tempfile.TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                upload_file = GlobalMetricsUploadFile(creator=self.user)
+                upload_file.file = SimpleUploadedFile(
+                    "metrics.xlsx",
+                    b"already-indexed",
+                    content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+                with self.captureOnCommitCallbacks(execute=True):
+                    upload_file.save()
+                upload_file.mark_processed()
+
+                result = process_global_metrics_upload_file(upload_file.pk)
+
+        self.assertTrue(result["skipped"])
+        mock_index.assert_not_called()
 
     def test_overwrite_storage_does_not_add_suffix(self):
         storage_path = "global_metrics_uploads/metrics.xlsx"


### PR DESCRIPTION
## O que esse PR faz?

Complementa o apply de métricas globais para o silver: o `update_by_query` continua assíncrono (`wait_for_completion=False`, para não estourar o timeout HTTP de 40s), mas o apply **espera cada task terminar** e só então acumula as estatísticas.

Também:

- ignora a reindexação do upload quando o arquivo já está processado;
- recusa o apply se o harvest ainda não foi indexado;
- retenta o `update_by_query` em 429 (circuit breaker), com backoff, em vez de abortar o restante dos grupos.

## Onde a revisão poderia começar?

Sugestão de ordem:

1. `harvest/global_metrics/opensearch.py` — `wait_for_update_task` e retry em 429
2. `harvest/global_metrics/apply.py` — espera da task, guard de `status` e `close_old_connections`
3. `harvest/global_metrics/process.py` — skip da reindexação
4. `harvest/tests.py` — skip, poll da task e retry

## Como este poderia ser testado manualmente?

1. No admin Wagtail, enviar um CSV/XLSX de métricas globais e aguardar a indexação (`status` processado).
2. Clicar em aplicar as métricas no silver.
3. Conferir os logs: o apply não deve mais devolver na hora com `task` sem resultado; `matches_found` e `updated` nas **Estatísticas** do snippet devem refletir os documentos atualizados.
4. Reenviar o mesmo arquivo já processado e confirmar que a reindexação é ignorada (`skipped`).
5. Tentar aplicar um upload ainda não processado e confirmar o erro.
6. Rodar os testes:

```console
docker compose -f local.yml run --rm --no-deps --entrypoint pytest django harvest/tests.py::GlobalMetricsUploadTaskTests harvest/tests.py::GlobalMetricsUploadFileTests --no-migrations
```

## Algum cenário de contexto que queira dar?

O PR #751 passou a disparar `update_by_query` com `wait_for_completion=False`. Isso evitou o `ConnectionTimeout` de 40s, mas o apply não esperava a conclusão: as stats `updated` / `matches_found` ficavam zeradas e, sem o poll, o loop enfileirava todas as tasks de uma vez e saturava o cluster (429 / SIGKILL do worker).

Este PR mantém o disparo assíncrono (HTTP curto) e faz poll em `tasks.get` até cada grupo terminar, um de cada vez. Assim o timeout HTTP some e as estatísticas passam a ser reais.

## Screenshots

Não aplicável (sem mudança de interface).

## Quais são os tickets relevantes?

Não há issue vinculada. Segue o PR #751.

## Referências

- [OpenSearch `update_by_query` — `wait_for_completion`](https://docs.opensearch.org/docs/latest/api-reference/document-apis/update-by-query/)
- [OpenSearch Task API](https://docs.opensearch.org/docs/latest/api-reference/tasks/)

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): alterações localizadas em código Python/Django do harvest; sem mudanças em infra ou dependências. A validação ocorre no CI após a abertura do PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
